### PR TITLE
Added forest type to fmus to the BO, business logic and API

### DIFF
--- a/app/admin/required_operator_document.rb
+++ b/app/admin/required_operator_document.rb
@@ -6,7 +6,8 @@ ActiveAdmin.register RequiredOperatorDocument do
   active_admin_paranoia
 
   actions :all
-  permit_params :name, :type, :valid_period, :country, :required_operator_document_group_id, :country_id,
+  permit_params :name, :type, :forest_type, :valid_period, :country,
+                :required_operator_document_group_id, :country_id,
                 translations_attributes: [:id, :locale, :explanation]
 
   csv do
@@ -39,6 +40,7 @@ ActiveAdmin.register RequiredOperatorDocument do
   filter :required_operator_document_group
   filter :country
   filter :type, as: :select, collection: %w(RequiredOperatorDocumentCountry RequiredOperatorDocumentFmu)
+  filter :forest_type, as: :select
   filter :name, as: :select
   filter :updated_at
 
@@ -50,6 +52,9 @@ ActiveAdmin.register RequiredOperatorDocument do
       f.input :country
       f.input :type, as: :select, collection: %w(RequiredOperatorDocumentCountry RequiredOperatorDocumentFmu),
                      include_blank: false, input_html: { disabled: editing }
+      f.input :forest_type, as: :select,
+              collection: Fmu::FOREST_TYPES.map { |ft| [ft.last[:label], ft.first] },
+              include_blank: true, input_html: { disabled: editing }
       f.input :name
       f.input :valid_period, label: 'Validity (days)'
       f.inputs 'Translated fields' do

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -2,6 +2,7 @@
 #= require activeadmin_addons/all
 #= require access_control
 #= require users
+#= require rod
 #= require index-filters
 #= require active_admin_sidebar
 

--- a/app/assets/javascripts/rod.js
+++ b/app/assets/javascripts/rod.js
@@ -1,0 +1,20 @@
+$(document).on('ready', function() {
+  updateFields();
+  $('#required_operator_document_type_input').on('change', function(){
+    updateFields();
+  })
+})
+
+function updateFields() {
+  var type = $('#required_operator_document_type').val();
+  var forestType = $('#required_operator_document_forest_type');
+
+  if (type === 'RequiredOperatorDocumentFmu') {
+    forestType.prop('disabled', false);
+    forestType.parent().show();
+  } else
+  {
+    forestType.prop('disabled', true);
+    forestType.parent().hide();
+  }
+}

--- a/app/models/concerns/forest_typeable.rb
+++ b/app/models/concerns/forest_typeable.rb
@@ -1,0 +1,18 @@
+require 'active_support/concern'
+
+module ForestTypeable
+  extend ActiveSupport::Concern
+
+  included do
+    enum forest_type: FOREST_TYPES.map {|x| {x.first => x.last[:index]}}.reduce({}, :merge)
+  end
+
+  class_methods do
+    FOREST_TYPES = {
+        fmu:     { index: 0, label: 'FMU' },
+        ufa:     { index: 1, label: 'UFA' },
+        cf:      { index: 2, label: 'Communal Forest' },
+        vdc:     { index: 3, label: 'Vente de Coupe'}
+    }
+  end
+end

--- a/app/models/fmu.rb
+++ b/app/models/fmu.rb
@@ -14,11 +14,13 @@
 #  certification_vlc  :boolean
 #  certification_vlo  :boolean
 #  certification_tltv :boolean
+#  forest_type        :integer          default("general"), not null
 #
 
 class Fmu < ApplicationRecord
   include ValidationHelper
   include Translatable
+  include ForestTypeable
   translates :name, touch: true
 
   active_admin_translates :name do
@@ -39,6 +41,7 @@ class Fmu < ApplicationRecord
 
   validates :country_id, presence: true
   validates :name, presence: true
+  validates :forest_type, presence: true
 
   before_save :update_geojson
   before_destroy :really_destroy_documents

--- a/app/models/required_operator_document.rb
+++ b/app/models/required_operator_document.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: required_operator_documents
@@ -13,9 +12,11 @@
 #  updated_at                          :datetime         not null
 #  valid_period                        :integer
 #  deleted_at                          :datetime
+#  forest_type                         :string
 #
 
 class RequiredOperatorDocument < ApplicationRecord
+  include ForestTypeable
   acts_as_paranoid
 
   translates :explanation

--- a/app/models/required_operator_document_country.rb
+++ b/app/models/required_operator_document_country.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: required_operator_documents
@@ -13,6 +12,7 @@
 #  updated_at                          :datetime         not null
 #  valid_period                        :integer
 #  deleted_at                          :datetime
+#  forest_type                         :string
 #
 
 class RequiredOperatorDocumentCountry < RequiredOperatorDocument
@@ -27,6 +27,4 @@ class RequiredOperatorDocumentCountry < RequiredOperatorDocument
       end
     end
   end
-
-
 end

--- a/app/models/required_operator_document_fmu.rb
+++ b/app/models/required_operator_document_fmu.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: required_operator_documents
@@ -13,15 +12,20 @@
 #  updated_at                          :datetime         not null
 #  valid_period                        :integer
 #  deleted_at                          :datetime
+#  forest_type                         :string
 #
 
 class RequiredOperatorDocumentFmu < RequiredOperatorDocument
+  include ForestTypeable
   has_many :operator_document_fmus
 
   after_create :create_operator_document_fmus
 
   def create_operator_document_fmus
-    Fmu.where(country_id: self.country_id).find_each do |fmu|
+    fmu_attributes = { country_id: self.country_id }
+    fmu_attributes[:forest_type] = self.forest_type if self.forest_type.present?
+
+    Fmu.where(fmu_attributes).find_each do |fmu|
       if fmu.operator.present? # This is to prevent faulty situations when the fmu has no operator id
         OperatorDocumentFmu.where(required_operator_document_id: self.id,
                                   operator_id: fmu.operator.id,

--- a/app/models/uploaded_document.rb
+++ b/app/models/uploaded_document.rb
@@ -2,13 +2,13 @@
 #
 # Table name: uploaded_documents
 #
-#  id              :integer          not null, primary key
-#  name            :string
-#  author          :string
-#  caption         :string
-#  file            :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id         :integer          not null, primary key
+#  name       :string
+#  author     :string
+#  caption    :string
+#  file       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 class UploadedDocument < ApplicationRecord

--- a/app/resources/v1/fmu_resource.rb
+++ b/app/resources/v1/fmu_resource.rb
@@ -5,13 +5,18 @@ module V1
     caching
     paginator :none
 
-    attributes :name, :geojson, :certification_fsc, :certification_pefc, :certification_olb,
+    attributes :name, :geojson, :forest_type,
+               :certification_fsc, :certification_pefc, :certification_olb,
                :certification_vlc, :certification_vlo, :certification_tltv
 
     has_one :country
     has_one :operator
 
     filters :country, :free, :certification
+
+    def forest_type
+      Fmu::FOREST_TYPES[@model.forest_type][:label]
+    end
 
     def custom_links(_)
       { self: nil }

--- a/app/resources/v1/operator_document_fmu_resource.rb
+++ b/app/resources/v1/operator_document_fmu_resource.rb
@@ -6,7 +6,7 @@ module V1
     attributes :expire_date, :start_date,
                :status, :created_at, :updated_at,
                :attachment, :operator_id, :required_operator_document_id,
-               :fmu_id, :current, :reason
+               :fmu_id, :forest_type, :current, :reason
 
     has_one :country
     has_one :fmu
@@ -19,6 +19,10 @@ module V1
     filters :type, :status, :operator_id, :current
 
     before_create :set_operator_id, :set_user_id
+
+    def forest_type
+      Fmu::FOREST_TYPES[@model.forest_type.to_sym][:label] if @model.forest_type
+    end
 
     def set_operator_id
       if context[:current_user].present? && context[:current_user].operator_id.present?

--- a/app/resources/v1/required_operator_document_fmu_resource.rb
+++ b/app/resources/v1/required_operator_document_fmu_resource.rb
@@ -3,13 +3,17 @@
 module V1
   class RequiredOperatorDocumentFmuResource < JSONAPI::Resource
     caching
-    attributes :name, :valid_period, :explanation
+    attributes :forest_type, :name, :valid_period, :explanation
 
     has_one :country
     has_one :required_operator_document_group
     has_many :operator_document_fmus
 
     filters :name, :type
+
+    def forest_type
+      Fmu::FOREST_TYPES[@model.forest_type.to_sym][:label] if @model.forest_type
+    end
 
     def custom_links(_)
       { self: nil }

--- a/db/migrate/20190627163848_add_type_to_fmus.rb
+++ b/db/migrate/20190627163848_add_type_to_fmus.rb
@@ -1,0 +1,6 @@
+class AddTypeToFmus < ActiveRecord::Migration[5.0]
+  def change
+    add_column :fmus, :forest_type, :integer, null: false, default: 0
+    add_index :fmus, :forest_type
+  end
+end

--- a/db/migrate/20190627171009_add_forest_type_to_required_operator_document.rb
+++ b/db/migrate/20190627171009_add_forest_type_to_required_operator_document.rb
@@ -1,0 +1,6 @@
+class AddForestTypeToRequiredOperatorDocument < ActiveRecord::Migration[5.0]
+  def change
+    add_column :required_operator_documents, :forest_type, :integer
+    add_index :required_operator_documents, :forest_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190617164842) do
+ActiveRecord::Schema.define(version: 20190627171009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,7 +185,9 @@ ActiveRecord::Schema.define(version: 20190617164842) do
     t.boolean  "certification_vlc"
     t.boolean  "certification_vlo"
     t.boolean  "certification_tltv"
+    t.integer  "forest_type",        default: 0,     null: false
     t.index ["country_id"], name: "index_fmus_on_country_id", using: :btree
+    t.index ["forest_type"], name: "index_fmus_on_forest_type", using: :btree
   end
 
   create_table "government_translations", force: :cascade do |t|
@@ -485,7 +487,9 @@ ActiveRecord::Schema.define(version: 20190617164842) do
     t.datetime "updated_at",                          null: false
     t.integer  "valid_period"
     t.datetime "deleted_at"
+    t.integer  "forest_type"
     t.index ["deleted_at"], name: "index_required_operator_documents_on_deleted_at", using: :btree
+    t.index ["forest_type"], name: "index_required_operator_documents_on_forest_type", using: :btree
     t.index ["required_operator_document_group_id"], name: "index_req_op_doc_group_id", using: :btree
     t.index ["type"], name: "index_required_operator_documents_on_type", using: :btree
   end

--- a/lib/tasks/forest_types.rake
+++ b/lib/tasks/forest_types.rake
@@ -1,0 +1,21 @@
+namespace :forest_types do
+  # Sets the attribute "forest_type" of fmus based on the geojson
+  task update: :environment do
+    query = <<-SQL
+      select id, geojson->'properties'->>'fmu_type' as forest_type 
+      from fmus 
+      where geojson->'properties'->>'fmu_type' is not null;
+    SQL
+
+    forest_types_map = {
+        'ventes_de_coupe' => Fmu::FOREST_TYPES[:vdc][:index],
+        'ufa' => Fmu::FOREST_TYPES[:ufa][:index],
+        'communal' => Fmu::FOREST_TYPES[:cf][:index]
+    }
+
+    result = ActiveRecord::Base.connection.execute(query)
+    result.each do |row|
+      Fmu.find(row['id']).update(forest_type: forest_types_map[row['forest_type']])
+    end
+  end
+end


### PR DESCRIPTION
Added a field called `forest-type` to fmus and required operator document.
In order to import the types of forest to the fmu I created a task called `forest_types:update` that will import them from the fmus' geojson.