### PR TITLE
Feature/contract signature

### DIFF
--- a/app/admin/operator_document.rb
+++ b/app/admin/operator_document.rb
@@ -54,7 +54,7 @@ ActiveAdmin.register OperatorDocument do
   end
 
   actions :all, except: [:destroy, :new, :create]
-  permit_params :name, :required_operator_document_id,
+  permit_params :name, :public, :required_operator_document_id,
                 :operator_id, :type, :status, :expire_date, :start_date,
                 :attachment, :uploaded_by, :reason, :note, :response_date
 
@@ -116,6 +116,7 @@ ActiveAdmin.register OperatorDocument do
       od.deleted_at.nil? && od.required_operator_document.deleted_at.nil?
     end
     column :current
+    column :public
     tag_column :status
     column :id
     column :country do |od|
@@ -165,6 +166,7 @@ ActiveAdmin.register OperatorDocument do
 
 
   filter :current
+  filter :public
   filter :id
   filter :required_operator_document,
          collection: RequiredOperatorDocument.
@@ -189,6 +191,7 @@ ActiveAdmin.register OperatorDocument do
       f.input :type, input_html: { disabled: true }
       f.input :uploaded_by
       f.input :status, include_blank: false
+      f.input :public
       f.input :attachment
       f.input :reason
       f.input :note
@@ -202,6 +205,7 @@ ActiveAdmin.register OperatorDocument do
   show title: proc{ "#{resource.operator.name} - #{resource.required_operator_document.name}" } do
     attributes_table do
       row :current
+      row :public
       tag_row :status
       row :required_operator_document
       row :operator

--- a/app/admin/required_operator_document.rb
+++ b/app/admin/required_operator_document.rb
@@ -6,8 +6,8 @@ ActiveAdmin.register RequiredOperatorDocument do
   active_admin_paranoia
 
   actions :all
-  permit_params :name, :type, :forest_type, :valid_period, :country,
-                :required_operator_document_group_id, :country_id,
+  permit_params :name, :type, :forest_type, :valid_period, :contract_signature,
+                :country, :required_operator_document_group_id, :country_id,
                 translations_attributes: [:id, :locale, :explanation]
 
   csv do
@@ -29,6 +29,7 @@ ActiveAdmin.register RequiredOperatorDocument do
     bool_column :exists do |rod|
       rod.deleted_at.nil?
     end
+    column :contract_signature
     column :required_operator_document_group
     column :country
     column :type
@@ -37,6 +38,7 @@ ActiveAdmin.register RequiredOperatorDocument do
     actions
   end
 
+  filter :contract_signature, as: :select, collection: [['True', true], ['False', false]]
   filter :required_operator_document_group
   filter :country
   filter :type, as: :select, collection: %w(RequiredOperatorDocumentCountry RequiredOperatorDocumentFmu)
@@ -49,6 +51,7 @@ ActiveAdmin.register RequiredOperatorDocument do
     f.inputs 'Required Operator Document Details' do
       editing = object.new_record? ? false : true
       f.input :required_operator_document_group
+      f.input :contract_signature
       f.input :country
       f.input :type, as: :select, collection: %w(RequiredOperatorDocumentCountry RequiredOperatorDocumentFmu),
                      include_blank: false, input_html: { disabled: editing }

--- a/app/models/fmu.rb
+++ b/app/models/fmu.rb
@@ -14,7 +14,7 @@
 #  certification_vlc  :boolean
 #  certification_vlo  :boolean
 #  certification_tltv :boolean
-#  forest_type        :integer          default("general"), not null
+#  forest_type        :integer          default("fmu"), not null
 #
 
 class Fmu < ApplicationRecord

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: operator_document_annexes
@@ -16,6 +15,7 @@
 #  user_id              :integer
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  public               :boolean          default(TRUE), not null
 #
 
 class OperatorDocumentAnnex < ApplicationRecord

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: operator_documents
@@ -22,8 +21,29 @@
 #  reason                        :text
 #  note                          :text
 #  response_date                 :datetime
+#  public                        :boolean          default(TRUE), not null
 #
 
 class OperatorDocumentCountry < OperatorDocument
   belongs_to :required_operator_document_country, foreign_key: 'required_operator_document_id'
+  after_create :invalidate_operator, if: -> { required_operator_document.contract_signature }
+  after_destroy :validate_operator,  if: -> { required_operator_document.contract_signature }
+
+  protected
+
+  def invalidate_operator
+    Operator.find(operator_id).update(approved: false) if operator.approved
+  end
+
+  def validate_operator
+    Operator.find(operator_id).update(approved: true) unless operator.approved
+  end
+
+  # If there are current documents of contract signature that are not
+  # valid or not required, then the operator is not approved
+  def update_operator_approved
+    approved = required_operator_document.contract_signature
+    Operator.update(operator_id: operator.id, approved: approved) unless operator.approved == approved
+  end
+
 end

--- a/app/models/operator_document_fmu.rb
+++ b/app/models/operator_document_fmu.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: operator_documents
@@ -22,6 +21,7 @@
 #  reason                        :text
 #  note                          :text
 #  response_date                 :datetime
+#  public                        :boolean          default(TRUE), not null
 #
 
 class OperatorDocumentFmu < OperatorDocument

--- a/app/models/required_operator_document_country.rb
+++ b/app/models/required_operator_document_country.rb
@@ -12,11 +12,14 @@
 #  updated_at                          :datetime         not null
 #  valid_period                        :integer
 #  deleted_at                          :datetime
-#  forest_type                         :string
+#  forest_type                         :integer
+#  contract_signature                  :boolean          default(FALSE), not null
 #
 
 class RequiredOperatorDocumentCountry < RequiredOperatorDocument
   has_many :operator_document_countries
+
+  validates_uniqueness_of :contract_signature, scope: :country_id, if: :contract_signature?
 
   after_create :create_operator_document_countries
 

--- a/app/models/required_operator_document_fmu.rb
+++ b/app/models/required_operator_document_fmu.rb
@@ -12,12 +12,15 @@
 #  updated_at                          :datetime         not null
 #  valid_period                        :integer
 #  deleted_at                          :datetime
-#  forest_type                         :string
+#  forest_type                         :integer
+#  contract_signature                  :boolean          default(FALSE), not null
 #
 
 class RequiredOperatorDocumentFmu < RequiredOperatorDocument
   include ForestTypeable
   has_many :operator_document_fmus
+
+  validates :contract_signature, absence: true
 
   after_create :create_operator_document_fmus
 

--- a/app/resources/v1/operator_document_annex_resource.rb
+++ b/app/resources/v1/operator_document_annex_resource.rb
@@ -12,7 +12,7 @@ module V1
 
     filters :status, :operator_document_id
 
-    before_create :set_user_id, :set_status
+    before_create :set_user_id, :set_status, :set_public
 
     def name
       show_attribute('name')
@@ -62,6 +62,10 @@ module V1
         @model.user_id = context[:current_user].id
         @model.uploaded_by = :operator
       end
+    end
+
+    def set_public
+      @model.public = false
     end
 
     def set_status

--- a/app/resources/v1/operator_document_country_resource.rb
+++ b/app/resources/v1/operator_document_country_resource.rb
@@ -1,56 +1,15 @@
 # frozen_string_literal: true
 
 module V1
-  class OperatorDocumentCountryResource < JSONAPI::Resource
-    caching
+  class OperatorDocumentCountryResource < OperatorDocumentResource
     attributes :expire_date, :start_date,
                :status, :created_at, :updated_at,
                :attachment, :operator_id, :required_operator_document_id,
                :current, :reason
 
-    has_one :country
-    has_one   :operator
-    has_one :required_operator_document
     has_one :required_operator_document_country
     has_many :documents
     has_many :operator_document_annexes
 
-    filters :type, :status, :operator_id, :current
-
-    before_create :set_operator_id, :set_user_id
-
-    def set_operator_id
-      if context[:current_user].present? && context[:current_user].operator_id.present?
-        @model.operator_id = context[:current_user].operator_id
-      end
-    end
-
-    def set_user_id
-      if context[:current_user].present?
-        @model.user_id = context[:current_user].id
-      end
-    end
-
-    def status
-      user = @context[:current_user]
-      app = @context[:app]
-      if (app != 'observations-tool' && user.present? && (user&.user_permission&.user_role =='admin' || user.is_operator?(@model.operator_id))) ||
-          %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
-        @model.status
-      else
-        :doc_not_provided
-      end
-    end
-
-    def custom_links(_)
-      { self: nil }
-    end
-
-    def self.attribute_caching_context(context)
-      {
-          locale: context[:locale],
-          owner: context[:current_user]
-      }
-    end
   end
 end

--- a/app/resources/v1/operator_document_fmu_resource.rb
+++ b/app/resources/v1/operator_document_fmu_resource.rb
@@ -1,62 +1,14 @@
 # frozen_string_literal: true
 
 module V1
-  class OperatorDocumentFmuResource < JSONAPI::Resource
-    caching
-    attributes :expire_date, :start_date,
-               :status, :created_at, :updated_at,
-               :attachment, :operator_id, :required_operator_document_id,
-               :fmu_id, :forest_type, :current, :reason
+  class OperatorDocumentFmuResource < OperatorDocumentResource
 
-    has_one :country
-    has_one :fmu
-    has_one   :operator
-    has_one :required_operator_document
     has_one :required_operator_document_fmu
     has_many :documents
-    has_many :operator_document_annexes
-
-    filters :type, :status, :operator_id, :current
-
-    before_create :set_operator_id, :set_user_id
 
     def forest_type
       rod = @model.required_operator_document
       Fmu::FOREST_TYPES[rod.forest_type.to_sym][:label] if rod.forest_type
-    end
-
-    def set_operator_id
-      if context[:current_user].present? && context[:current_user].operator_id.present?
-        @model.operator_id = context[:current_user].operator_id
-      end
-    end
-
-    def set_user_id
-      if context[:current_user].present?
-        @model.user_id = context[:current_user].id
-      end
-    end
-
-    def status
-      user = @context[:current_user]
-      app = @context[:app]
-      if (app != 'observations-tool' && user.present? && (user&.user_permission&.user_role =='admin' || user.is_operator?(@model.operator_id))) ||
-          %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
-        @model.status
-      else
-        :doc_not_provided
-      end
-    end
-
-    def custom_links(_)
-      { self: nil }
-    end
-
-    def self.attribute_caching_context(context)
-      {
-          locale: context[:locale],
-          owner: context[:current_user]
-      }
     end
   end
 end

--- a/app/resources/v1/operator_document_resource.rb
+++ b/app/resources/v1/operator_document_resource.rb
@@ -21,7 +21,7 @@ module V1
     def set_operator_id
       if context[:current_user].present? && context[:current_user].operator_id.present?
         @model.operator_id = context[:current_user].operator_id
-        @model.uplodaded_by = :operator
+        @model.uploaded_by = :operator
       end
     end
 
@@ -42,15 +42,19 @@ module V1
       end
     end
 
+    # TODO: Implement permissions system here
     def status
-      user = @context[:current_user]
-      app = @context[:app]
-      if (app != 'observations-tool' && user.present? && (user&.user_permission&.user_role =='admin' || user.is_operator?(@model.operator_id))) ||
-          %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
-        @model.status
-      else
-        :doc_not_provided
-      end
+      return @model.status if can_see_document?
+      return :doc_not_provided unless document_public?
+
+      hidden_document_status
+    end
+
+    def attachment
+      return @model.attachment if can_see_document?
+      return :doc_not_provided unless document_public?
+
+      { url: nil }
     end
 
     def self.records(options = {})
@@ -64,7 +68,6 @@ module V1
       end
     end
 
-
     def custom_links(_)
       { self: nil }
     end
@@ -75,6 +78,25 @@ module V1
           locale: context[:locale],
           owner: context[:current_user]
       }
+    end
+
+    def document_public?
+      @model.public || @model.operator.approved
+    end
+
+    def can_see_document?
+      user = @context[:current_user]
+      app = @context[:app]
+
+      return false if app == 'observations-tool'
+      return true if user&.user_permission&.user_role =='admin'
+      return true if user&.is_operator?(@model.operator_id)
+      false
+    end
+
+    def hidden_document_status
+      return @model.status if %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
+      return :doc_not_provided
     end
   end
 end

--- a/app/resources/v1/operator_document_resource.rb
+++ b/app/resources/v1/operator_document_resource.rb
@@ -16,13 +16,17 @@ module V1
 
     filters :type, :status, :operator_id, :current
 
-    before_create :set_operator_id, :set_user_id
+    before_create :set_operator_id, :set_user_id, :set_public
 
     def set_operator_id
       if context[:current_user].present? && context[:current_user].operator_id.present?
         @model.operator_id = context[:current_user].operator_id
         @model.uplodaded_by = :operator
       end
+    end
+
+    def set_public
+      @model.public = false
     end
 
     def self.updatable_fields(context)

--- a/app/resources/v1/operator_resource.rb
+++ b/app/resources/v1/operator_resource.rb
@@ -3,8 +3,8 @@
 module V1
   class OperatorResource < JSONAPI::Resource
     caching
-    attributes :name, :operator_type, :concession, :is_active, :logo, :details,
-               :percentage_valid_documents_fmu, :percentage_valid_documents_country,
+    attributes :name, :approved, :operator_type, :concession, :is_active, :logo,
+               :details, :percentage_valid_documents_fmu, :percentage_valid_documents_country,
                :percentage_valid_documents_all, :score, :obs_per_visit,
                :website, :address, :fa_id, :country_doc_rank, :country_operators,
                :delete_logo

--- a/db/migrate/20190701181155_add_contract_signature_to_documents.rb
+++ b/db/migrate/20190701181155_add_contract_signature_to_documents.rb
@@ -1,0 +1,15 @@
+class AddContractSignatureToDocuments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :required_operator_documents, :contract_signature, :boolean, default: false, null: false
+    add_index :required_operator_documents, :contract_signature
+
+    add_column :operators, :approved, :boolean, default: true, null: false
+    add_index :operators, :approved
+
+    add_column :operator_documents, :public, :boolean, default: true, null: false
+    add_index :operator_documents, :public
+
+    add_column :operator_document_annexes, :public, :boolean, default: true, null: false
+    add_index :operator_document_annexes, :public
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190627171009) do
+ActiveRecord::Schema.define(version: 20190701181155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -368,10 +368,12 @@ ActiveRecord::Schema.define(version: 20190627171009) do
     t.string   "attachment"
     t.integer  "uploaded_by"
     t.integer  "user_id"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.boolean  "public",               default: true, null: false
     t.index ["deleted_at"], name: "index_operator_document_annexes_on_deleted_at", using: :btree
     t.index ["operator_document_id"], name: "index_operator_document_annexes_on_operator_document_id", using: :btree
+    t.index ["public"], name: "index_operator_document_annexes_on_public", using: :btree
     t.index ["status"], name: "index_operator_document_annexes_on_status", using: :btree
     t.index ["user_id"], name: "index_operator_document_annexes_on_user_id", using: :btree
   end
@@ -382,8 +384,8 @@ ActiveRecord::Schema.define(version: 20190627171009) do
     t.date     "start_date"
     t.integer  "fmu_id"
     t.integer  "required_operator_document_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
     t.integer  "status"
     t.integer  "operator_id"
     t.string   "attachment"
@@ -394,11 +396,13 @@ ActiveRecord::Schema.define(version: 20190627171009) do
     t.text     "reason"
     t.text     "note"
     t.datetime "response_date"
+    t.boolean  "public",                        default: true, null: false
     t.index ["current"], name: "index_operator_documents_on_current", using: :btree
     t.index ["deleted_at"], name: "index_operator_documents_on_deleted_at", using: :btree
     t.index ["expire_date"], name: "index_operator_documents_on_expire_date", using: :btree
     t.index ["fmu_id"], name: "index_operator_documents_on_fmu_id", using: :btree
     t.index ["operator_id"], name: "index_operator_documents_on_operator_id", using: :btree
+    t.index ["public"], name: "index_operator_documents_on_public", using: :btree
     t.index ["required_operator_document_id"], name: "index_operator_documents_on_required_operator_document_id", using: :btree
     t.index ["start_date"], name: "index_operator_documents_on_start_date", using: :btree
     t.index ["status"], name: "index_operator_documents_on_status", using: :btree
@@ -436,6 +440,8 @@ ActiveRecord::Schema.define(version: 20190627171009) do
     t.string   "website"
     t.integer  "country_doc_rank"
     t.integer  "country_operators"
+    t.boolean  "approved",                           default: true, null: false
+    t.index ["approved"], name: "index_operators_on_approved", using: :btree
     t.index ["country_id"], name: "index_operators_on_country_id", using: :btree
     t.index ["fa_id"], name: "index_operators_on_fa_id", using: :btree
     t.index ["is_active"], name: "index_operators_on_is_active", using: :btree
@@ -483,11 +489,13 @@ ActiveRecord::Schema.define(version: 20190627171009) do
     t.integer  "required_operator_document_group_id"
     t.string   "name"
     t.integer  "country_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
     t.integer  "valid_period"
     t.datetime "deleted_at"
     t.integer  "forest_type"
+    t.boolean  "contract_signature",                  default: false, null: false
+    t.index ["contract_signature"], name: "index_required_operator_documents_on_contract_signature", using: :btree
     t.index ["deleted_at"], name: "index_required_operator_documents_on_deleted_at", using: :btree
     t.index ["forest_type"], name: "index_required_operator_documents_on_forest_type", using: :btree
     t.index ["required_operator_document_group_id"], name: "index_req_op_doc_group_id", using: :btree

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -22,6 +22,7 @@
 #  website                            :string
 #  country_doc_rank                   :integer
 #  country_operators                  :integer
+#  approved                           :boolean          default(TRUE), not null
 #
 
 FactoryGirl.define do

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -22,6 +22,7 @@
 #  website                            :string
 #  country_doc_rank                   :integer
 #  country_operators                  :integer
+#  approved                           :boolean          default(TRUE), not null
 #
 
 require 'rails_helper'


### PR DESCRIPTION
Added .a property called `contract_signature` to a  `RequiredOperatorDocumentCountry`.
This type of `RequiredOperatorDocument` is unique per country and when it exists, the operators become not validated until they upload this document.
The documents are now public or private, and when the operator is not validated, the private documents are hidden from the list of documents