### PR TITLE
Fixes BO listing of Annexes

### DIFF
--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -80,7 +80,6 @@ ActiveAdmin.register OperatorDocumentAnnex do
     end
     column :fmu, sortable: 'fmu_translations.name' do |od|
       fmu = OperatorDocument.unscoped.find(od.operator_document_id).fmu
-          #fmu = od.operator_document.fmu
       link_to(fmu.name, admin_fmu_path(fmu.id)) if fmu
     end
 

--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -79,7 +79,8 @@ ActiveAdmin.register OperatorDocumentAnnex do
       link_to(o.name, admin_producer_path(o.id))
     end
     column :fmu, sortable: 'fmu_translations.name' do |od|
-      fmu = od.operator_document.fmu
+      fmu = OperatorDocument.unscoped.find(od.operator_document_id).fmu
+          #fmu = od.operator_document.fmu
       link_to(fmu.name, admin_fmu_path(fmu.id)) if fmu
     end
 


### PR DESCRIPTION
In the BO - Operator Document Annex - the listing would fail if the Operator Document has been deleted