### PR TITLE
Epic/change document history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ erd.png
 
 # Ignore IDE files
 .idea
+
+# Ignore test tasks
+/lib/tasks/test.rake

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,9 @@ gem 'rubyzip'
 gem 'globalize-versioning'
 gem 'paper_trail'
 
+# Interactors
+gem "interactor", "~> 3.0"
+
 group :development, :test do
   gem 'byebug',                    platform: :mri
   gem 'faker'
@@ -124,7 +127,6 @@ group :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers', '~> 4.0.1'
   gem 'simplecov'
-  gem 'timecop'
 end
 
 # Server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     tzinfo-data (1.2019.3)
@@ -633,7 +632,6 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  timecop
   tzinfo-data
   valid_url
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)
       responders (>= 2, < 4)
+    interactor (3.1.2)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -590,6 +591,7 @@ DEPENDENCIES
   globalize (= 5.1.0)
   globalize-versioning
   guard
+  interactor (~> 3.0)
   jsonapi-resources (= 0.9.0)
   jwt
   listen (~> 3.0.5)

--- a/app/admin/custom_admin_header.rb
+++ b/app/admin/custom_admin_header.rb
@@ -51,7 +51,13 @@ class CustomAdminHeader < ActiveAdmin::Views::Header
               li { link_to 'Sawmills',             admin_sawmills_path }
               li { link_to 'Document Categories',  admin_required_operator_document_groups_path }
               li { link_to 'Required Documents',   admin_required_operator_documents_path }
-              li { link_to 'Producer Documents',   admin_operator_documents_path }
+              li do
+                text_node content_tag 'a', 'Producer Documents', class: '-with-children'
+                ul do
+                  li { link_to 'Producer Documents',     admin_operator_documents_path }
+                  li { link_to 'Old Producer Documents', admin_operator_document_histories_path }
+                end
+              end
               li { link_to 'Annexes',              admin_operator_document_annexes_path }
               li do
                 text_node content_tag 'a', 'Settings', class: '-with-children'

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -112,7 +112,7 @@ ActiveAdmin.register_page "Dashboard" do
     columns do
       column do
         panel "First 20 Pending Documents out of #{OperatorDocument.doc_pending.count}" do
-          table_for OperatorDocument.actual.doc_pending.order('updated_at DESC').limit(20).each do
+          table_for OperatorDocument.doc_pending.order('updated_at DESC').limit(20).each do
             column('Operator') { |od| link_to od.operator.name, admin_producer_path(od.operator_id) }
             column('Name') { |od| link_to od.required_operator_document.name, admin_operator_document_path(od.id) }
             column('Creation Date') { |od| od.created_at.strftime("%A, %d/%b/%Y") }

--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -79,7 +79,7 @@ ActiveAdmin.register OperatorDocumentAnnex do
     end
     tag_column :status
     column :operator_documents do |od|
-      doc = OperatorDocument.unscoped.find(annex_document.documentable_id)
+      doc = OperatorDocument.unscoped.find(od.annex_document.documentable_id)
       link_to(doc.required_operator_document.name, admin_operator_document_path(doc.id))
     end
     column :operator_documents_history do |od|

--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -44,7 +44,7 @@ ActiveAdmin.register OperatorDocumentAnnex do
   end
 
   actions :all, except: [:destroy, :new]
-  permit_params :name, :operator_document_id, :status, :expire_date, :start_date,
+  permit_params :name, :status, :expire_date, :start_date,
                 :attachment, :uploaded_by
 
   csv do
@@ -79,10 +79,8 @@ ActiveAdmin.register OperatorDocumentAnnex do
     end
     tag_column :status
     column :operator_documents do |od|
-      od.annex_documents_actual.each_with_object([]) do |ad, links|
-        doc = OperatorDocument.unscoped.find(ad.documentable_id)
-        links << link_to(doc.required_operator_document.name, admin_operator_document_path(doc.id))
-      end.reduce(:+)
+      doc = OperatorDocument.unscoped.find(annex_document.documentable_id)
+      link_to(doc.required_operator_document.name, admin_operator_document_path(doc.id))
     end
     column :operator_documents_history do |od|
       od.annex_documents_history.each_with_object([]) do |ad, links|

--- a/app/admin/operator_document_annex.rb
+++ b/app/admin/operator_document_annex.rb
@@ -92,7 +92,7 @@ ActiveAdmin.register OperatorDocumentAnnex do
       begin
         o = od.annex_documents_history.first.documentable.operator
         link_to(o.name, admin_producer_path(o.id))
-      rescue
+      rescue StandardError
       end
     end
     column :fmu, sortable: 'fmu_translations.name' do |od|
@@ -114,15 +114,15 @@ ActiveAdmin.register OperatorDocumentAnnex do
 
 
   filter :annex_documents_documentable_of_OperatorDocument_type_required_operator_document_name_equals,
-          as: :select,
-          label: 'Operator Document',
-          collection: RequiredOperatorDocument.order(:name).pluck(:name)
+         as: :select,
+         label: 'Operator Document',
+         collection: RequiredOperatorDocument.order(:name).pluck(:name)
 
   filter :annex_documents_documentable_of_OperatorDocument_type_operator_translations_name_equals,
-          as: :select,
-          label: 'Operator',
-          collection: Operator.with_translations(I18n.locale)
-                          .order('operator_translations.name').pluck(:name)
+         as: :select,
+         label: 'Operator',
+         collection: Operator.with_translations(I18n.locale)
+                         .order('operator_translations.name').pluck(:name)
   filter :annex_documents_documentable_of_OperatorDocument_type_fmu_translations_name_equals,
          as: :select,
          label: 'FMU',

--- a/app/admin/operator_document_history.rb
+++ b/app/admin/operator_document_history.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register OperatorDocumentHistory do
+  extend BackRedirectable
+  back_redirect
+
+  menu false
+  config.order_clause
+
+  sidebar 'Annexes', only: :show do
+    attributes_table_for resource do
+      ul do
+        resource.operator_document_annexes.collect do |annex|
+          li link_to(annex.name, admin_operator_document_annex_path(annex.id))
+        end
+      end
+    end
+  end
+
+  actions :index, :show
+
+  csv do
+    column :exists do |o|
+      o.deleted_at.nil? && o.required_operator_document.deleted_at.nil?
+    end
+    column :status
+    column :id
+    column :required_operator_document do |o|
+      o.required_operator_document.name
+    end
+    column :country do |o|
+      o.required_operator_document.country.name
+    end
+    column :Type do |o|
+      if o.required_operator_document.present?
+        o.required_operator_document.type == 'RequiredOperatorDocumentFmu' ? 'Fmu' : 'Operator'
+      else
+        RequiredOperatorDocument.unscoped.find(o.required_operator_document_id).type
+      end
+    end
+    column :operator do |o|
+      o.operator.name
+    end
+    column :fmu do |o|
+      o.fmu&.name
+    end
+    column 'Legal Category' do |o|
+      if o.required_operator_document.present?
+        o.required_operator_document.required_operator_document_group.name
+      else
+        RequiredOperatorDocument.unscoped.find(o.required_operator_document_id).required_operator_document_group.name
+      end
+    end
+    column :user do |o|
+      o.user&.name
+    end
+    column :expire_date
+    column :start_date
+    column :created_at
+    column :uploaded_by
+    column :attachment do |o|
+      o.attachment&.filename
+    end
+    # TODO: Reactivate rubocop and fix this
+    # rubocop:disable Rails/OutputSafety
+    column 'Annexes' do |o|
+      links = []
+      o.operator_document_annexes.each { |a| links << a.name }
+      links.join(' ').html_safe
+    end
+    # rubocop:enable Rails/OutputSafety
+    column :reason
+    column :note
+    column :response_date
+  end
+
+  index do
+    column :public
+    tag_column :status
+    column :id
+    column :country do |od|
+      od.required_operator_document.country
+    end
+    column 'Required Document', :required_operator_document, sortable: 'required_operator_documents.name' do |od|
+      if od.required_operator_document.present?
+        link_to od.required_operator_document.name, admin_required_operator_document_path(od.required_operator_document)
+      else
+        RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).name
+      end
+    end
+    column :Type, sortable: 'required_operator_documents.type' do |od|
+      if od.required_operator_document.present?
+        od.required_operator_document.type == 'RequiredOperatorDocumentFmu' ? 'Fmu' : 'Operator'
+      else
+        RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).type
+      end
+    end
+    column :operator, sortable: 'operator_translations.name'
+    column :fmu, sortable: 'fmu_translations.name'
+    column 'Legal Category' do |od|
+      if od.required_operator_document.present?
+        od.required_operator_document.required_operator_document_group.name
+      else
+        RequiredOperatorDocument.unscoped.find(od.required_operator_document_id).required_operator_document_group.name
+      end
+    end
+    column :user, sortable: 'users.name'
+    column :expire_date
+    column :start_date
+    column :created_at
+    column :uploaded_by
+    column :source
+    column 'attachment' do |od|
+      if od&.document_file&.attachment
+        link_to od.document_file.attachment.identifier, od.document_file.attachment.url
+      end
+    end
+    # TODO: Reactivate rubocop and fix this
+    # rubocop:disable Rails/OutputSafety
+    column 'Annexes' do |od|
+      links = []
+      od.operator_document_annexes.each { |a| links << link_to(a.id, admin_operator_document_annex_path(a)) }
+      links.join(' ').html_safe
+    end
+    # rubocop:enable Rails/OutputSafety
+    column :reason
+    column :note
+    column :response_date
+    actions
+  end
+
+  filter :public
+  filter :id
+  filter :required_operator_document_country_id, label: 'Country', as: :select,
+                                                 collection: Country.with_translations(I18n.locale).order('country_translations.name')
+  filter :required_operator_document,
+         collection: RequiredOperatorDocument.
+             joins(country: :translations)
+                         .order('required_operator_documents.name')
+                         .where(country_translations: { locale: I18n.locale }).all.map { |x| ["#{x.name} - #{x.country.name}", x.id] }
+  filter :operator, label: 'Operator', as: :select,
+                    collection: -> { Operator.with_translations(I18n.locale).order('operator_translations.name') }
+  filter :status, as: :select, collection: OperatorDocument.statuses
+  filter :type, as: :select
+  filter :source, as: :select, collection: OperatorDocument.sources
+  filter :updated_at
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -8,8 +8,11 @@ class ApiController < ActionController::API
   include JSONAPI::ActsAsResourceController
 
   def context
-    { current_user: current_user, app: params[:app],
-      action: params[:action], locale: (params[:locale] || I18n.default_locale) }
+    { current_user: current_user,
+      app: params[:app],
+      action: params[:action],
+      filters: params[:filter],
+      locale: (params[:locale] || I18n.default_locale) }
   end
 
   before_action :check_access, :authenticate

--- a/app/controllers/v1/operator_document_histories_controller.rb
+++ b/app/controllers/v1/operator_document_histories_controller.rb
@@ -7,8 +7,8 @@ module V1
 
     def index
 
-      return render json: { error: 'You must provide an operator-id' }, status: :bad_request unless params.dig('filter', 'operator-id').present?
-      return render json: { error: 'You must provide a date' }, status: :bad_request unless params.dig('filter', 'date').present?
+      return render json: { error: 'You must provide an operator-id' }, status: :bad_request if params.dig('filter', 'operator-id').blank?
+      return render json: { error: 'You must provide a date' }, status: :bad_request if params.dig('filter', 'date').blank?
 
       super
     end

--- a/app/controllers/v1/operator_document_histories_controller.rb
+++ b/app/controllers/v1/operator_document_histories_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module V1
+  class OperatorDocumentHistoriesController < ApiController
+    skip_before_action :authenticate, only: [:index, :show]
+    load_and_authorize_resource class: 'OperatorDocumentHistory'
+  end
+end

--- a/app/controllers/v1/operator_document_histories_controller.rb
+++ b/app/controllers/v1/operator_document_histories_controller.rb
@@ -11,7 +11,7 @@ module V1
       if result.success?
         super
       else
-        return render json: { error: result.message }, status: :bad_request
+        render json: { error: result.message }, status: :bad_request
       end
     end
   end

--- a/app/controllers/v1/operator_document_histories_controller.rb
+++ b/app/controllers/v1/operator_document_histories_controller.rb
@@ -6,11 +6,13 @@ module V1
     load_and_authorize_resource class: 'OperatorDocumentHistory'
 
     def index
+      result = SearchDocumentInTime.call(params)
 
-      return render json: { error: 'You must provide an operator-id' }, status: :bad_request if params.dig('filter', 'operator-id').blank?
-      return render json: { error: 'You must provide a date' }, status: :bad_request if params.dig('filter', 'date').blank?
-
-      super
+      if result.success?
+        super
+      else
+        return render json: { error: result.message }, status: :bad_request
+      end
     end
   end
 end

--- a/app/controllers/v1/operator_document_histories_controller.rb
+++ b/app/controllers/v1/operator_document_histories_controller.rb
@@ -4,5 +4,13 @@ module V1
   class OperatorDocumentHistoriesController < ApiController
     skip_before_action :authenticate, only: [:index, :show]
     load_and_authorize_resource class: 'OperatorDocumentHistory'
+
+    def index
+
+      return render json: { error: 'You must provide an operator-id' }, status: :bad_request unless params.dig('filter', 'operator-id').present?
+      return render json: { error: 'You must provide a date' }, status: :bad_request unless params.dig('filter', 'date').present?
+
+      super
+    end
   end
 end

--- a/app/interactors/search_document_in_time.rb
+++ b/app/interactors/search_document_in_time.rb
@@ -5,7 +5,7 @@ class SearchDocumentInTime
 
   def call
     filter = context.filter
-    context.fail!(message: 'Please add the date and operator-id filters') unless filter.present?
+    context.fail!(message: 'Please add the date and operator-id filters') if filter.blank?
     context.fail!(message: 'You must provide an operator-id') if filter['operator-id'].blank?
     context.fail!(message: 'You must provide a date') if filter['date'].blank?
 

--- a/app/interactors/search_document_in_time.rb
+++ b/app/interactors/search_document_in_time.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SearchDocumentInTime
+  include Interactor
+
+  def call
+    context.fail!(message: 'You must provide an operator-id') if params.dig('filter', 'operator-id').blank?
+    context.fail!(message: 'You must provide a date') if params.dig('filter', 'date').blank?
+    context.fail!(message: 'Operator must be an integer') unless params['filter']['operator-id'].is_a?(Integer)
+
+    begin
+      params['filter']['operator-id'].to_date
+    rescue ArgumentError
+      context.fail!(message: 'Invalid date format. Use: YYYY-MM-DD')
+    end
+  end
+end

--- a/app/interactors/search_document_in_time.rb
+++ b/app/interactors/search_document_in_time.rb
@@ -4,12 +4,18 @@ class SearchDocumentInTime
   include Interactor
 
   def call
-    context.fail!(message: 'You must provide an operator-id') if params.dig('filter', 'operator-id').blank?
-    context.fail!(message: 'You must provide a date') if params.dig('filter', 'date').blank?
-    context.fail!(message: 'Operator must be an integer') unless params['filter']['operator-id'].is_a?(Integer)
+    filter = context.filter
+    context.fail!(message: 'Please add the date and operator-id filters') unless filter.present?
+    context.fail!(message: 'You must provide an operator-id') if filter['operator-id'].blank?
+    context.fail!(message: 'You must provide a date') if filter['date'].blank?
 
     begin
-      params['filter']['operator-id'].to_date
+      Integer(filter['operator-id'])
+    rescue ArgumentError
+      context.fail!(message: 'Operator must be an integer')
+    end
+    begin
+      filter['date'].to_date
     rescue ArgumentError
       context.fail!(message: 'Invalid date format. Use: YYYY-MM-DD')
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,10 +38,11 @@ class Ability
 
 
     can :read, [Country, Fmu, Category, Subcategory, Law, Species,
-                OperatorDocument, RequiredOperatorDocument, RequiredOperatorDocumentGroup,
-                ObservationReport, ObservationDocument, Partner, OperatorDocumentAnnex,
-                Sawmill, Faq, Tutorial, HowTo, Tool, CountryLink, CountryVpa,
-                RequiredGovDocumentGroup, RequiredGovDocument, GovDocument, GovFile, ScoreOperatorDocument]
+                OperatorDocument, OperatorDocumentHistory, RequiredOperatorDocument,
+                RequiredOperatorDocumentGroup, ObservationReport, ObservationDocument,
+                Partner, OperatorDocumentAnnex, Sawmill, Faq, Tutorial, HowTo, Tool,
+                CountryLink, CountryVpa, RequiredGovDocumentGroup, RequiredGovDocument,
+                GovDocument, GovFile, ScoreOperatorDocument]
     can :read, Observation, is_active: true
     can :read, Observer, is_active: true
     can :read, Operator, is_active: true

--- a/app/models/annex_document.rb
+++ b/app/models/annex_document.rb
@@ -1,4 +1,24 @@
+# == Schema Information
+#
+# Table name: annex_documents
+#
+#  id                         :integer          not null, primary key
+#  documentable_type          :string           not null
+#  documentable_id            :integer          not null
+#  operator_document_annex_id :integer          not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
 class AnnexDocument < ApplicationRecord
   belongs_to :documentable, polymorphic: true
   belongs_to :operator_document_annex
+
+  # An annex can only belong to one Operator Document
+  validates_uniqueness_of :documentable_id,
+                          conditions: -> { where(documentable_type: 'OperatorDocument')},
+                          scope: :operator_document_annex_id
+
+  # A Documentable cannot have the same annex more than once
+  validates_uniqueness_of :operator_document_annex_id,
+                          scope: [:documentable_type, :documentable_id]
 end

--- a/app/models/annex_document.rb
+++ b/app/models/annex_document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: annex_documents
@@ -15,7 +17,7 @@ class AnnexDocument < ApplicationRecord
 
   # An annex can only belong to one Operator Document
   validates_uniqueness_of :documentable_id,
-                          conditions: -> { where(documentable_type: 'OperatorDocument')},
+                          conditions: -> { where(documentable_type: 'OperatorDocument') },
                           scope: :operator_document_annex_id
 
   # A Documentable cannot have the same annex more than once

--- a/app/models/annex_document.rb
+++ b/app/models/annex_document.rb
@@ -1,0 +1,4 @@
+class AnnexDocument < ApplicationRecord
+  belongs_to :documentable, polymorphic: true
+  belongs_to :operator_document_annex
+end

--- a/app/models/document_file.rb
+++ b/app/models/document_file.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: document_files
+#
+#  id         :integer          not null, primary key
+#  attachment :string
+#  file_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class DocumentFile < ApplicationRecord
+  mount_base64_uploader :attachment, DocumentFileUploader
+
+  def generate_file_name(operator)
+    return if operator.blank?
+
+    self.filename = '' + operator.name[0...30]&.parameterize + '-' + operator.required_operator_document.name[0...100]&.parameterize + '-' + Date.today.to_s
+  end
+end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -48,9 +48,9 @@ class Operator < ApplicationRecord
   has_many :all_fmu_operators, class_name: 'FmuOperator', inverse_of: :operator, dependent: :destroy
   has_many :all_fmus, through: :all_fmu_operators, source: :fmu
 
-  has_many :operator_documents, -> { actual }
-  has_many :operator_document_countries, -> { actual }
-  has_many :operator_document_fmus, -> { actual }
+  has_many :operator_documents
+  has_many :operator_document_countries
+  has_many :operator_document_fmus
 
   has_many :score_operator_documents
   has_one :score_operator_document, ->{ current }, class_name: 'ScoreOperatorDocument', inverse_of: :operator
@@ -138,8 +138,7 @@ class Operator < ApplicationRecord
     RequiredOperatorDocumentCountry.where(country_id: country).find_each do |rodc|
       if OperatorDocumentCountry.where(required_operator_document_id: rodc.id, operator_id: id).blank?
         OperatorDocumentCountry.where(required_operator_document_id: rodc.id, operator_id: id,
-                                      status: OperatorDocument.statuses[:doc_not_provided],
-                                      current: true).create!
+                                      status: OperatorDocument.statuses[:doc_not_provided]).create!
       end
     end
 
@@ -148,8 +147,7 @@ class Operator < ApplicationRecord
       Fmu.joins(:fmu_operators).where(fmu_operators: { operator_id: id, current: true }).find_each do |fmu|
         unless OperatorDocumentFmu.where(required_operator_document_id: rodf.id, operator_id: id, fmu_id: fmu.id).any?
           OperatorDocumentFmu.where(required_operator_document_id: rodf.id, operator_id: id, fmu_id: fmu.id,
-                                    status: OperatorDocument.statuses[:doc_not_provided],
-                                    current: true).create!
+                                    status: OperatorDocument.statuses[:doc_not_provided]).create!
         end
       end
     end
@@ -175,7 +173,7 @@ class Operator < ApplicationRecord
     if operator_document_countries.none?
       RequiredOperatorDocumentCountry.where(country_id: country).find_each do |rodc|
         OperatorDocumentCountry.where(required_operator_document_id: rodc.id, operator_id: id).first_or_create do |odc|
-          odc.update!(status: OperatorDocument.statuses[:doc_not_provided], current: true)
+          odc.update!(status: OperatorDocument.statuses[:doc_not_provided])
         end
       end
     end
@@ -184,7 +182,7 @@ class Operator < ApplicationRecord
       RequiredOperatorDocumentFmu.where(country_id: country).find_each do |rodf|
         self.fmus.find_each do |fmu|
           OperatorDocumentFmu.where(required_operator_document_id: rodf.id, operator_id: id, fmu_id: fmu.id).first_or_create do |odf|
-            odf.update!(status: OperatorDocument.statuses[:doc_not_provided], current: true)
+            odf.update!(status: OperatorDocument.statuses[:doc_not_provided])
           end
         end
       end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -52,6 +52,10 @@ class Operator < ApplicationRecord
   has_many :operator_document_countries
   has_many :operator_document_fmus
 
+  has_many :operator_document_histories
+  has_many :operator_document_country_histories
+  has_many :operator_document_fmu_histories
+
   has_many :score_operator_documents
   has_one :score_operator_document, ->{ current }, class_name: 'ScoreOperatorDocument', inverse_of: :operator
   has_many :ranking_operator_documents

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -17,6 +17,7 @@
 #  address       :string
 #  website       :string
 #  approved      :boolean          default("true"), not null
+#  email         :string
 #  name          :string
 #  details       :text
 #

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -77,7 +77,7 @@ class OperatorDocument < ApplicationRecord
     mapping = self.attributes.except *NON_HISTORICAL_ATTRIBUTES
     mapping['operator_document_id'] = self.id
     mapping['type'] += 'History'
-    attrs.select! { |x| self.attributes.keys.include? x }
+    attrs.select! { |x| OperatorDocumentHistory.new.attributes.keys.include? x }
 
     OperatorDocumentHistory.create mapping.merge(attrs)
   end

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -25,6 +25,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 class OperatorDocument < ApplicationRecord
@@ -35,6 +36,7 @@ class OperatorDocument < ApplicationRecord
   belongs_to :required_operator_document, -> { with_archived }, required: true
   belongs_to :fmu
   belongs_to :user
+  belongs_to :document_file, required: :false
   has_many :operator_document_annexes
 
   mount_base64_uploader :attachment, OperatorDocumentUploader
@@ -104,6 +106,8 @@ class OperatorDocument < ApplicationRecord
   def approved?
     %w(doc_not_required doc_valid).include?(status)
   end
+
+  def create_history; end
 
   private
 

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -30,17 +30,20 @@ class OperatorDocument < ApplicationRecord
   has_paper_trail
   acts_as_paranoid
 
+  #  delegate :attachment, to: :document_file
+
   belongs_to :operator, optional: false, touch: true
   belongs_to :required_operator_document, -> { with_archived }, required: true
   belongs_to :fmu
   belongs_to :user
   belongs_to :document_file, optional: :true
   has_many :operator_document_annexes, as: :documentable
+  accepts_nested_attributes_for :document_file
 
   before_validation :set_expire_date, unless: :expire_date?
 
-  validates_presence_of :start_date, if: :attachment?
-  validates_presence_of :expire_date, if: :attachment? # TODO We set expire_date on before_validation
+  validates_presence_of :start_date, if: :document_file_id?
+  validates_presence_of :expire_date, if: :document_file_id # TODO We set expire_date on before_validation
   validate :reason_or_file
 
   before_save :set_type, on: %w[create update]
@@ -108,7 +111,6 @@ class OperatorDocument < ApplicationRecord
            deleted_at: nil, uploaded_by: nil, user_id: nil, reason: nil, note: nil, response_date: nil,
            source: nil, source_info: nil, document_file_id: nil
 
-
     true
   end
 
@@ -121,7 +123,7 @@ class OperatorDocument < ApplicationRecord
 
   def set_status
     status =
-      if attachment.present? || reason.present?
+      if document_file_id.present? || reason.present?
         :doc_pending
       else
         :doc_not_provided

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -14,7 +14,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer
@@ -38,13 +37,11 @@ class OperatorDocument < ApplicationRecord
   belongs_to :document_file, optional: :true
   has_many :operator_document_annexes, as: :documentable
 
-  mount_base64_uploader :attachment, OperatorDocumentUploader
-
   before_validation :set_expire_date, unless: :expire_date?
 
   validates_presence_of :start_date, if: :attachment?
   validates_presence_of :expire_date, if: :attachment? # TODO We set expire_date on before_validation
-  validate :reason_or_attachment
+  validate :reason_or_file
 
   before_save :set_type, on: %w[create update]
   before_create :set_status
@@ -141,8 +138,8 @@ class OperatorDocument < ApplicationRecord
     pending_documents.each { |x| x.destroy }
   end
 
-  def reason_or_attachment
-    return if self.attachment.blank? || self.reason.blank?
+  def reason_or_file
+    return if self.document_file_id.blank? || self.reason.blank?
 
     self.errors[:reason] << 'Cannot have a reason not to have a document'
   end

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -86,7 +86,7 @@ class OperatorDocument < ApplicationRecord
     mapping = self.attributes.except *NON_HISTORICAL_ATTRIBUTES
     mapping['operator_document_id'] = self.id
     mapping['type'] += 'History'
-    attrs.select! { |x| OperatorDocumentHistory.new.attributes.keys.include? x }
+    attrs.select! { |x| OperatorDocumentHistory.new.attributes.key?(x) }
 
     odh = OperatorDocumentHistory.create mapping.merge(attrs)
     return odh unless odh.persisted?

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -70,6 +70,18 @@ class OperatorDocument < ApplicationRecord
   enum uploaded_by: { operator: 1, monitor: 2, admin: 3, other: 4 }
   enum source: { company: 1, forest_atlas: 2, other_source: 3 }
 
+  NON_HISTORICAL_ATTRIBUTES = %w[id attachment current deleted_at].freeze
+
+  # Creates an OperatorDocumentHistory for the current OperatorDocument
+  def create_history(attrs = {})
+    mapping = self.attributes.except *NON_HISTORICAL_ATTRIBUTES
+    mapping['operator_document_id'] = self.id
+    mapping['type'] += 'History'
+    attrs.select! { |x| self.attributes.keys.include? x }
+
+    OperatorDocumentHistory.create mapping.merge(attrs)
+  end
+
   def set_expire_date
     self.expire_date = start_date + required_operator_document.valid_period.days rescue start_date
   end
@@ -106,8 +118,6 @@ class OperatorDocument < ApplicationRecord
   def approved?
     %w(doc_not_required doc_valid).include?(status)
   end
-
-  def create_history; end
 
   private
 

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -37,7 +37,7 @@ class OperatorDocument < ApplicationRecord
   belongs_to :fmu
   belongs_to :user
   belongs_to :document_file, required: :false
-  has_many :operator_document_annexes
+  has_many :operator_document_annexes, as: :documentable
 
   mount_base64_uploader :attachment, OperatorDocumentUploader
 

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -4,19 +4,20 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                   :integer          not null, primary key
-#  operator_document_id :integer
-#  name                 :string
-#  start_date           :date
-#  expire_date          :date
-#  deleted_at           :date
-#  status               :integer
-#  attachment           :string
-#  uploaded_by          :integer
-#  user_id              :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  public               :boolean          default("true"), not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  start_date        :date
+#  expire_date       :date
+#  deleted_at        :date
+#  status            :integer
+#  attachment        :string
+#  uploaded_by       :integer
+#  user_id           :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  public            :boolean          default("true"), not null
+#  documentable_id   :integer
+#  documentable_type :string
 #
 
 class OperatorDocumentAnnex < ApplicationRecord

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -26,8 +26,8 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   mount_base64_uploader :attachment, OperatorDocumentAnnexUploader
 
-  belongs_to :documentable, polymorphic: true
   belongs_to :user
+  has_many :annex_documents
 
   before_validation(on: :create) do
     self.status = OperatorDocumentAnnex.statuses[:doc_pending]
@@ -49,6 +49,10 @@ class OperatorDocumentAnnex < ApplicationRecord
     number_of_documents = documents_to_expire.count
     documents_to_expire.find_each(&:expire_document)
     Rails.logger.info "Expired #{number_of_documents} document annexes"
+  end
+
+  def documentables
+    annex_documents.map {|x| x.documentable }
   end
 
   def expire_document_annex

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -25,7 +25,7 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   mount_base64_uploader :attachment, OperatorDocumentAnnexUploader
 
-  belongs_to :operator_document, optional: false
+  belongs_to :documentable, polymorphic: true
   belongs_to :user
 
   before_validation(on: :create) do

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -26,10 +26,10 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   belongs_to :user
   has_many :annex_documents
-  has_one :annex_document, -> { where(documentable_type: 'OperatorDocument')},
+  has_one :annex_document, -> { where(documentable_type: 'OperatorDocument') },
           class_name: 'AnnexDocument'
   has_one :operator_document, through: :annex_document, required: false, source: 'documentable', source_type: 'OperatorDocument'
-  has_many :annex_documents_history, -> { where(documentable_type: 'OperatorDocumentHistory')},
+  has_many :annex_documents_history, -> { where(documentable_type: 'OperatorDocumentHistory') },
            class_name: 'AnnexDocument'
 
   before_validation(on: :create) do
@@ -54,7 +54,7 @@ class OperatorDocumentAnnex < ApplicationRecord
   end
 
   def documentables
-    annex_documents.map {|x| x.documentable }
+    annex_documents.map { |x| x.documentable }
   end
 
   def expire_document_annex

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -26,8 +26,9 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   belongs_to :user
   has_many :annex_documents
-  has_many :annex_documents_actual, -> { where(documentable_type: 'OperatorDocument')},
-           class_name: 'AnnexDocument'
+  has_one :annex_document, -> { where(documentable_type: 'OperatorDocument')},
+          class_name: 'AnnexDocument'
+  has_one :operator_document, through: :annex_document, required: false, source: 'documentable', source_type: 'OperatorDocument'
   has_many :annex_documents_history, -> { where(documentable_type: 'OperatorDocumentHistory')},
            class_name: 'AnnexDocument'
 

--- a/app/models/operator_document_annex.rb
+++ b/app/models/operator_document_annex.rb
@@ -4,20 +4,18 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                :integer          not null, primary key
-#  name              :string
-#  start_date        :date
-#  expire_date       :date
-#  deleted_at        :date
-#  status            :integer
-#  attachment        :string
-#  uploaded_by       :integer
-#  user_id           :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  public            :boolean          default("true"), not null
-#  documentable_id   :integer
-#  documentable_type :string
+#  id          :integer          not null, primary key
+#  name        :string
+#  start_date  :date
+#  expire_date :date
+#  deleted_at  :date
+#  status      :integer
+#  attachment  :string
+#  uploaded_by :integer
+#  user_id     :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  public      :boolean          default("true"), not null
 #
 
 class OperatorDocumentAnnex < ApplicationRecord
@@ -28,12 +26,15 @@ class OperatorDocumentAnnex < ApplicationRecord
 
   belongs_to :user
   has_many :annex_documents
+  has_many :annex_documents_actual, -> { where(documentable_type: 'OperatorDocument')},
+           class_name: 'AnnexDocument'
+  has_many :annex_documents_history, -> { where(documentable_type: 'OperatorDocumentHistory')},
+           class_name: 'AnnexDocument'
 
   before_validation(on: :create) do
     self.status = OperatorDocumentAnnex.statuses[:doc_pending]
   end
 
-  validates_presence_of :operator_document_id
   validates_presence_of :start_date
   validates_presence_of :status
 

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -14,7 +14,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -15,7 +15,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -29,7 +29,7 @@
 class OperatorDocumentCountry < OperatorDocument
   belongs_to :required_operator_document_country, foreign_key: 'required_operator_document_id'
 
-  after_update :update_operator_approved, if: -> { required_operator_document.contract_signature && current }
+  after_update :update_operator_approved, if: -> { required_operator_document.contract_signature }
 
   protected
 

--- a/app/models/operator_document_country.rb
+++ b/app/models/operator_document_country.rb
@@ -25,6 +25,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 class OperatorDocumentCountry < OperatorDocument

--- a/app/models/operator_document_country_history.rb
+++ b/app/models/operator_document_country_history.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: operator_document_histories
+#
+#  id                            :integer          not null, primary key
+#  type                          :string
+#  expire_date                   :date
+#  start_date                    :date
+#  status                        :integer
+#  uploaded_by                   :integer
+#  reason                        :text
+#  note                          :text
+#  response_date                 :datetime
+#  public                        :boolean
+#  source                        :integer
+#  source_info                   :string
+#  fmu_id                        :integer
+#  document_file_id              :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  operator_document_id          :integer
+#  operator_id                   :integer
+#  user_id                       :integer
+#  required_operator_document_id :integer
+#
+class OperatorDocumentCountryHistory < OperatorDocumentHistory
+
+end

--- a/app/models/operator_document_country_history.rb
+++ b/app/models/operator_document_country_history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: operator_document_histories

--- a/app/models/operator_document_fmu.rb
+++ b/app/models/operator_document_fmu.rb
@@ -14,7 +14,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/app/models/operator_document_fmu.rb
+++ b/app/models/operator_document_fmu.rb
@@ -15,7 +15,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/app/models/operator_document_fmu.rb
+++ b/app/models/operator_document_fmu.rb
@@ -25,6 +25,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 class OperatorDocumentFmu < OperatorDocument

--- a/app/models/operator_document_fmu_history.rb
+++ b/app/models/operator_document_fmu_history.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: operator_document_histories
+#
+#  id                            :integer          not null, primary key
+#  type                          :string
+#  expire_date                   :date
+#  start_date                    :date
+#  status                        :integer
+#  uploaded_by                   :integer
+#  reason                        :text
+#  note                          :text
+#  response_date                 :datetime
+#  public                        :boolean
+#  source                        :integer
+#  source_info                   :string
+#  fmu_id                        :integer
+#  document_file_id              :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  operator_document_id          :integer
+#  operator_id                   :integer
+#  user_id                       :integer
+#  required_operator_document_id :integer
+#
+class OperatorDocumentFmuHistory < OperatorDocumentHistory
+
+end

--- a/app/models/operator_document_fmu_history.rb
+++ b/app/models/operator_document_fmu_history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: operator_document_histories

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -1,9 +1,35 @@
+# == Schema Information
+#
+# Table name: operator_document_histories
+#
+#  id                            :integer          not null, primary key
+#  type                          :string
+#  expire_date                   :date
+#  start_date                    :date
+#  status                        :integer
+#  uploaded_by                   :integer
+#  reason                        :text
+#  note                          :text
+#  response_date                 :datetime
+#  public                        :boolean
+#  source                        :integer
+#  source_info                   :string
+#  fmu_id                        :integer
+#  document_file_id              :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  operator_document_id          :integer
+#  operator_id                   :integer
+#  user_id                       :integer
+#  required_operator_document_id :integer
+#
 class OperatorDocumentHistory < ApplicationRecord
-  belongs_to :operator, optional: false, touch: true
+  belongs_to :operator, optional: false
   belongs_to :required_operator_document, -> { with_archived }, required: true
-  belongs_to :fmu
-  belongs_to :user
-  belongs_to :document_file, required: :false
+  belongs_to :fmu, required: false
+  belongs_to :user, required: false
+  belongs_to :document_file, optional: :true
+  has_many :operator_document_annexes, as: :documentable
 
   enum status: { doc_not_provided: 0, doc_pending: 1, doc_invalid: 2, doc_valid: 3, doc_expired: 4, doc_not_required: 5 }
   enum uploaded_by: { operator: 1, monitor: 2, admin: 3, other: 4 }

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: operator_document_histories
@@ -26,8 +28,8 @@
 class OperatorDocumentHistory < ApplicationRecord
   belongs_to :operator, optional: false
   belongs_to :required_operator_document, -> { with_archived }, required: true
-  belongs_to :fmu, required: false
-  belongs_to :user, required: false
+  belongs_to :fmu, optional: true
+  belongs_to :user, optional: true
   belongs_to :document_file, optional: :true
   has_many :annex_documents, as: :documentable
   has_many :operator_document_annexes, through: :annex_documents

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -43,11 +43,11 @@ class OperatorDocumentHistory < ApplicationRecord
   # @param String date the date at which to fetch the state
   def self.from_operator_at_date(operator_id, date)
     query = <<~SQL
-        (select * from
-        (select row_number() over (partition by required_operator_document_id, fmu_id order by updated_at desc), *
-        from operator_document_histories
-        where operator_id = #{operator_id} AND updated_at < '#{date.to_date.to_s(:db)}') as sq
-        where sq.row_number = 1) as operator_document_histories
+      (select * from
+      (select row_number() over (partition by required_operator_document_id, fmu_id order by updated_at desc), *
+      from operator_document_histories
+      where operator_id = #{operator_id} AND updated_at < '#{date.to_date.to_s(:db)}') as sq
+      where sq.row_number = 1) as operator_document_histories
     SQL
 
     from(query)

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -1,0 +1,12 @@
+class OperatorDocumentHistory < ApplicationRecord
+  belongs_to :operator, optional: false, touch: true
+  belongs_to :required_operator_document, -> { with_archived }, required: true
+  belongs_to :fmu
+  belongs_to :user
+  belongs_to :document_file, required: :false
+
+  enum status: { doc_not_provided: 0, doc_pending: 1, doc_invalid: 2, doc_valid: 3, doc_expired: 4, doc_not_required: 5 }
+  enum uploaded_by: { operator: 1, monitor: 2, admin: 3, other: 4 }
+  enum source: { company: 1, forest_atlas: 2, other_source: 3 }
+
+end

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -29,7 +29,8 @@ class OperatorDocumentHistory < ApplicationRecord
   belongs_to :fmu, required: false
   belongs_to :user, required: false
   belongs_to :document_file, optional: :true
-  has_many :operator_document_annexes, as: :documentable
+  has_many :annex_documents, as: :documentable
+  has_many :operator_document_annexes, through: :annex_documents
 
   enum status: { doc_not_provided: 0, doc_pending: 1, doc_invalid: 2, doc_valid: 3, doc_expired: 4, doc_not_required: 5 }
   enum uploaded_by: { operator: 1, monitor: 2, admin: 3, other: 4 }

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -38,4 +38,18 @@ class OperatorDocumentHistory < ApplicationRecord
   enum uploaded_by: { operator: 1, monitor: 2, admin: 3, other: 4 }
   enum source: { company: 1, forest_atlas: 2, other_source: 3 }
 
+  # Returns the operator documents for an operator at a point in time
+  # @param String operator_id The operator id
+  # @param String date the date at which to fetch the state
+  def self.from_operator_at_date(operator_id, date)
+    query = <<~SQL
+        (select * from
+        (select row_number() over (partition by required_operator_document_id, fmu_id order by updated_at desc), *
+        from operator_document_histories
+        where operator_id = #{operator_id} AND updated_at < '#{date.to_date.to_s(:db)}') as sq
+        where sq.row_number = 1) as operator_document_histories
+    SQL
+
+    from(query)
+  end
 end

--- a/app/models/required_operator_document.rb
+++ b/app/models/required_operator_document.rb
@@ -30,9 +30,14 @@ class RequiredOperatorDocument < ApplicationRecord
 
   belongs_to :required_operator_document_group
   belongs_to :country
+
   has_many :operator_documents, dependent: :destroy
   has_many :operator_document_fmus
   has_many :operator_document_countries
+
+  has_many :operator_document_histories
+  has_many :operator_document_country_histories
+  has_many :operator_document_fmu_histories
 
   validates :valid_period, numericality: { greater_than: 0 }
 

--- a/app/models/required_operator_document_country.rb
+++ b/app/models/required_operator_document_country.rb
@@ -30,7 +30,7 @@ class RequiredOperatorDocumentCountry < RequiredOperatorDocument
   def create_operator_document_countries
     Operator.where(country_id: self.country_id).find_each do |operator|
       OperatorDocumentCountry.where(required_operator_document_id: self.id, operator_id: operator.id).first_or_create do |odc|
-        odc.update!(status: OperatorDocument.statuses[:doc_not_provided], current: true)
+        odc.update!(status: OperatorDocument.statuses[:doc_not_provided])
       end
     end
   end

--- a/app/models/required_operator_document_fmu.rb
+++ b/app/models/required_operator_document_fmu.rb
@@ -37,7 +37,7 @@ class RequiredOperatorDocumentFmu < RequiredOperatorDocument
         OperatorDocumentFmu.where(required_operator_document_id: self.id,
                                   operator_id: fmu.operator.id,
                                   fmu_id: fmu.id).first_or_create do |odf|
-          odf.update!(status: OperatorDocument.statuses[:doc_not_provided], current: true)
+          odf.update!(status: OperatorDocument.statuses[:doc_not_provided])
         end
       end
     end

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -23,6 +23,12 @@ module OperatorDocumentable
       { self: nil }
     end
 
+    def attachment
+      return @model&.document_file&.attachment if can_see_document? || document_public?
+
+      { url: nil }
+    end
+
     def document_public?
       @model.public || @model.operator.approved
     end

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -7,7 +7,7 @@ module OperatorDocumentable
     attributes :expire_date, :start_date,
                :status, :created_at, :updated_at,
                :attachment, :operator_id, :required_operator_document_id,
-               :fmu_id, :current, :uploaded_by, :reason, :note, :response_date,
+               :fmu_id, :uploaded_by, :reason, :note, :response_date,
                :public, :source_info
     attribute  :source_type, delegate: :source
 
@@ -15,9 +15,9 @@ module OperatorDocumentable
     has_one :fmu
     has_one :operator
     has_one :required_operator_document
-    has_many :operator_document_annexes
+    has_many :operator_document_annexes, foreign_key_on: :related
 
-    filters :type, :status, :operator_id, :current
+    filters :type, :status, :operator_id
 
     def custom_links(_)
       { self: nil }

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module OperatorDocumentable
+  extend ActiveSupport::Concern
+
+  included do
+    attributes :expire_date, :start_date,
+               :status, :created_at, :updated_at,
+               :attachment, :operator_id, :required_operator_document_id,
+               :fmu_id, :current, :uploaded_by, :reason, :note, :response_date,
+               :public, :source_info
+    attribute  :source_type, delegate: :source
+
+    has_one :country
+    has_one :fmu
+    has_one :operator
+    has_one :required_operator_document
+    has_many :operator_document_annexes
+
+    filters :type, :status, :operator_id, :current
+
+    def custom_links(_)
+      { self: nil }
+    end
+
+    def document_public?
+      @model.public || @model.operator.approved
+    end
+
+    def can_see_document?
+      user = @context[:current_user]
+      app = @context[:app]
+
+      return false if app == 'observations-tool'
+      return true if user&.user_permission&.user_role =='admin'
+      return true if user&.is_operator?(@model.operator_id)
+
+      false
+    end
+
+    def hidden_document_status
+      return @model.status if %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
+
+      :doc_not_provided
+    end
+  end
+
+  module ClassMethods
+  end
+end

--- a/app/resources/v1/operator_document_annex_resource.rb
+++ b/app/resources/v1/operator_document_annex_resource.rb
@@ -5,11 +5,11 @@ module V1
     include CacheableByLocale
     include CacheableByCurrentUser
     caching
-    attributes :operator_document_id, :name,
+    attributes :name,
                :start_date, :expire_date, :status, :attachment,
                :uploaded_by, :created_at, :updated_at
 
-    has_one :operator_document
+    has_one :operator_document, foreign_key_on: :related
     has_one :user
 
     filters :status

--- a/app/resources/v1/operator_document_annex_resource.rb
+++ b/app/resources/v1/operator_document_annex_resource.rb
@@ -12,7 +12,7 @@ module V1
     has_one :operator_document
     has_one :user
 
-    filters :status, :operator_document_id
+    filters :status
 
     before_create :set_user_id, :set_status, :set_public
 

--- a/app/resources/v1/operator_document_country_history_resource.rb
+++ b/app/resources/v1/operator_document_country_history_resource.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module V1
+  class OperatorDocumentCountryHistoryResource < OperatorDocumentHistoryResource
+    has_one :required_operator_document_country
+    has_many :documents
+
+    def fetchable_fields
+      super - [:fmu_id]
+    end
+  end
+end

--- a/app/resources/v1/operator_document_fmu_history_resource.rb
+++ b/app/resources/v1/operator_document_fmu_history_resource.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  class OperatorDocumentFmuHistoryResource < OperatorDocumentHistoryResource
+    has_one :required_operator_document_fmu
+    has_many :documents
+
+    def forest_type
+      rod = @model.required_operator_document
+      Fmu::FOREST_TYPES[rod.forest_type.to_sym][:geojson_label] if rod.forest_type
+    end
+  end
+end

--- a/app/resources/v1/operator_document_history_resource.rb
+++ b/app/resources/v1/operator_document_history_resource.rb
@@ -22,7 +22,7 @@ module V1
       date = context.dig(:filters, 'date').to_date
 
       OperatorDocumentHistory.from_operator_at_date(operator, date)
-    rescue
+    rescue StandardError
       return OperatorDocumentHistory.where('true = false') unless operator && date
     end
   end

--- a/app/resources/v1/operator_document_history_resource.rb
+++ b/app/resources/v1/operator_document_history_resource.rb
@@ -8,15 +8,24 @@ module V1
     caching
     immutable
 
-    def attachment
-      return @model.attachment if can_see_document? || document_public?
-
-      { url: nil }
-    end
-
     # TODO
     def self.records(options = {})
-      OperatorDocumentHistory.all
+      context = options[:context]
+      user = context[:current_user]
+      operator = user&.operator
+      return OperatorDocumentHistory.where('true = false') unless operator
+
+      date = "AND updated_at < '2017-10-06'"
+      # date = ''
+      query = <<~SQL
+        (select * from
+        (select row_number() over (partition by required_operator_document_id, fmu_id order by created_at asc), *
+        from operator_document_histories
+        where operator_id = #{operator.id} #{date}) as sq
+        where sq.row_number = 1) as operator_document_histories
+      SQL
+
+      OperatorDocumentHistory.from(query)
     end
   end
 end

--- a/app/resources/v1/operator_document_history_resource.rb
+++ b/app/resources/v1/operator_document_history_resource.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  class OperatorDocumentHistoryResource < JSONAPI::Resource
+    include CacheableByLocale
+    include CacheableByCurrentUser
+    include OperatorDocumentable
+    caching
+    immutable
+
+    def attachment
+      return @model.attachment if can_see_document? || document_public?
+
+      { url: nil }
+    end
+
+    # TODO
+    def self.records(options = {})
+      OperatorDocumentHistory.all
+    end
+  end
+end

--- a/app/resources/v1/operator_document_history_resource.rb
+++ b/app/resources/v1/operator_document_history_resource.rb
@@ -19,18 +19,11 @@ module V1
     def self.records(options = {})
       context = options[:context]
       operator = context.dig(:filters, 'operator-id')
-      date = context.dig(:filters, 'date')
+      date = context.dig(:filters, 'date').to_date
+
+      OperatorDocumentHistory.from_operator_at_date(operator, date)
+    rescue
       return OperatorDocumentHistory.where('true = false') unless operator && date
-
-      query = <<~SQL
-        (select * from
-        (select row_number() over (partition by required_operator_document_id, fmu_id order by created_at asc), *
-        from operator_document_histories
-        where operator_id = #{operator} AND updated_at < '#{date}') as sq
-        where sq.row_number = 1) as operator_document_histories
-      SQL
-
-      OperatorDocumentHistory.from(query)
     end
   end
 end

--- a/app/resources/v1/operator_document_resource.rb
+++ b/app/resources/v1/operator_document_resource.rb
@@ -20,8 +20,8 @@ module V1
 
     filters :type, :status, :operator_id, :current
 
-    before_create :set_operator_id, :set_user_id, :set_public, :set_source
-    before_update :set_status_pending
+    before_create :set_public, :set_source
+    before_update :set_operator_id, :set_user_id, :set_status_pending
 
     def set_operator_id
       if context[:current_user].present? && context[:current_user].operator_id.present?
@@ -72,19 +72,6 @@ module V1
 
     def self.records(options = {})
       OperatorDocument.all
-
-      # TODO : This code is faulty. I'm not sure if any of this is necessary.
-      # It could be that when logged in, the operator could see his old
-      # documents and that those should be added to the list of documents
-
-      # context = options[:context]
-      # user = context[:current_user]
-      # app = context[:app]
-      # if app != 'observations-tool' && user.present? && user.operator_id && context[:action] != 'destroy'
-      #   OperatorDocument.actual.from_user(user.operator_id)
-      # else
-      #   OperatorDocument.all
-      # end
     end
 
     def custom_links(_)

--- a/app/resources/v1/operator_document_resource.rb
+++ b/app/resources/v1/operator_document_resource.rb
@@ -4,24 +4,10 @@ module V1
   class OperatorDocumentResource < JSONAPI::Resource
     include CacheableByLocale
     include CacheableByCurrentUser
+    include OperatorDocumentable
     caching
-    attributes :expire_date, :start_date,
-               :status, :created_at, :updated_at,
-               :attachment, :operator_id, :required_operator_document_id,
-               :fmu_id, :current, :uploaded_by, :reason, :note, :response_date,
-               :public, :source_info
-    attribute  :source_type, delegate: :source
 
-    has_one :country
-    has_one :fmu
-    has_one :operator
-    has_one :required_operator_document
-    has_many :operator_document_annexes
-
-    filters :type, :status, :operator_id, :current
-
-    before_create :set_public, :set_source
-    before_update :set_operator_id, :set_user_id, :set_status_pending
+    before_update :set_source, :set_public, :set_operator_id, :set_user_id, :set_status_pending
 
     def set_operator_id
       if context[:current_user].present? && context[:current_user].operator_id.present?
@@ -55,17 +41,14 @@ module V1
       end
     end
 
-    # TODO: Implement permissions system here
     def status
       return @model.status if can_see_document?
-
-      # return :doc_not_provided unless document_public?
 
       hidden_document_status
     end
 
     def attachment
-      return @model.attachment if can_see_document? || document_public?
+      return @model&.document_file&.attachment if can_see_document? || document_public?
 
       { url: nil }
     end
@@ -76,27 +59,6 @@ module V1
 
     def custom_links(_)
       { self: nil }
-    end
-
-    def document_public?
-      @model.public || @model.operator.approved
-    end
-
-    def can_see_document?
-      user = @context[:current_user]
-      app = @context[:app]
-
-      return false if app == 'observations-tool'
-      return true if user&.user_permission&.user_role =='admin'
-      return true if user&.is_operator?(@model.operator_id)
-
-      false
-    end
-
-    def hidden_document_status
-      return @model.status if %w[doc_not_provided doc_valid doc_expired doc_not_required].include?(@model.status)
-
-      :doc_not_provided
     end
   end
 end

--- a/app/resources/v1/operator_document_resource.rb
+++ b/app/resources/v1/operator_document_resource.rb
@@ -47,12 +47,6 @@ module V1
       hidden_document_status
     end
 
-    def attachment
-      return @model&.document_file&.attachment if can_see_document? || document_public?
-
-      { url: nil }
-    end
-
     def self.records(options = {})
       OperatorDocument.all
     end

--- a/app/resources/v1/operator_resource.rb
+++ b/app/resources/v1/operator_resource.rb
@@ -20,6 +20,10 @@ module V1
     has_many :operator_document_fmus
     has_many :operator_document_countries
 
+    has_many :operator_document_histories
+    has_many :operator_document_country_histories
+    has_many :operator_document_fmu_histories
+
     filters :country, :is_active, :name, :operator_type, :fa
 
     before_create :set_active

--- a/app/resources/v1/required_operator_document_resource.rb
+++ b/app/resources/v1/required_operator_document_resource.rb
@@ -11,11 +11,18 @@ module V1
     has_many :operator_documents
     has_many :operator_document_fmus
     has_many :operator_document_countries
+    has_many :operator_document_histories
+    has_many :operator_document_country_histories
+    has_many :operator_document_fmu_histories
 
     filters :name, :type
 
     def custom_links(_)
       { self: nil }
+    end
+
+    def self.records(options={})
+      RequiredOperatorDocument.unscoped
     end
   end
 end

--- a/app/services/document_migration_service.rb
+++ b/app/services/document_migration_service.rb
@@ -49,18 +49,8 @@ class DocumentMigrationService
       unless history.persisted?
         Rails.logger.warn "Couldn't create history for document #{od.id}"
         not_to_destroy << od.id
-        next
       end
-      next if od.operator_document_annexes.none?
-
-      update_annexes od, history
     end
     OperatorDocument.unscoped.where.not(current: true, id: not_to_destroy).delete_all
-  end
-
-  private
-
-  def update_annexes(document, history)
-    document.operator_document_annexes.update_all documentable_type: 'OperatorDocumentHistory', documentable_id: history.id
   end
 end

--- a/app/services/document_migration_service.rb
+++ b/app/services/document_migration_service.rb
@@ -51,6 +51,11 @@ class DocumentMigrationService
         not_to_destroy << od.id
       end
     end
+
+    AnnexDocument.where(documentable_type: 'OperatorDocument')
+      .joins('join operator_documents on operator_documents.id = annex_documents.documentable_id')
+      .where('operator_documents.current != true AND operator_documents.id not in (?)', not_to_destroy)
+      .delete_all
     OperatorDocument.unscoped.where.not(current: true, id: not_to_destroy).delete_all
   end
 end

--- a/app/services/document_migration_service.rb
+++ b/app/services/document_migration_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class DocumentMigrationService
+  def initialize(*args)
+    args.map!(&:to_sym)
+    @attachments = args.include? :attachments
+    @documents = args.include? :documents
+  end
+
+  def call
+    migrate_attachments
+    migrate_documents
+  end
+
+  private
+
+  # Migrates the attachments in OperatorDocument to an external class: DocumentFile
+  def migrate_attachments
+    return unless @attachments
+
+    OperatorDocument.where.not(attachment: nil).find_each.with_index do |od, i|
+      Rails.logger.info "Migrated #{i} documents" if i % 10
+      df = DocumentFile.create! file_name: od.attachment_identifier.split('.').first, attachment: od.attachment
+      # rubocop:disable Rails/SkipsModelValidations
+      od.update_column :document_file_id, df.id
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+
+  # Creates anOperatorDocumentHistory for each OperatorDocument
+  # and deletes the ones that aren't active
+  def migrate_documents
+    return unless @documents
+
+    # TODO Finish this
+    OperatorDocument.find_each do |od|
+      od.create_history
+    end
+  end
+end

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class DocumentFileUploader < CarrierWave::Uploader::Base
+  storage :file
+
+  def store_dir
+    "uploads/operator_document_file/#{mounted_as}/#{model.id}"
+  end
+
+  def extension_whitelist
+    %w(pdf doc docx txt csv xml jpg jpeg png exif tiff bmp)
+  end
+
+  def exists?
+    file.present?
+  end
+
+  def filename
+    filename = model.file_name
+    extension = super&.split('.')&.last
+    extension = extension.blank? ? '' : '.' + extension
+    filename + extension
+  end
+
+  def original_filename
+    if file.present?
+      file.filename
+    else
+      super
+    end
+  end
+end

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -17,6 +17,7 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
 
   def filename
     filename = model.file_name
+    filename ||= super&.split('.')&.first
     extension = super&.split('.')&.last
     extension = extension.blank? ? '' : '.' + extension
     filename + extension

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,14 +52,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  config.after_initialize do
-    # Set Time.now to September 1, 2015 12:00:00 AM (at this instant)
-    t = Time.local(2015, 9, 1, 12, 0, 0, 0)
-    Timecop.travel(t)
-  end
-
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 5000 }
   config.action_mailer.delivery_method = :test
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,8 +40,8 @@ Rails.application.routes.draw do
       jsonapi_resources :observation_documents do; end
       jsonapi_resources :observation_reports do; end
       jsonapi_resources :operator_documents, except: [:create, :update] do; end
-      jsonapi_resources :operator_document_fmus do; end
-      jsonapi_resources :operator_document_countries do; end
+      jsonapi_resources :operator_document_fmus, except: [:create] do; end
+      jsonapi_resources :operator_document_countries, except: [:create] do; end
       jsonapi_resources :required_operator_documents do; end
       jsonapi_resources :required_operator_document_groups do; end
       jsonapi_resources :partners do; end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       jsonapi_resources :observation_documents do; end
       jsonapi_resources :observation_reports do; end
       jsonapi_resources :operator_documents, except: [:create, :update] do; end
+      jsonapi_resources :operator_document_histories do; end
       jsonapi_resources :operator_document_fmus, except: [:create] do; end
       jsonapi_resources :operator_document_countries, except: [:create] do; end
       jsonapi_resources :required_operator_documents do; end

--- a/db/migrate/20201023073505_create_document_files.rb
+++ b/db/migrate/20201023073505_create_document_files.rb
@@ -1,0 +1,13 @@
+class CreateDocumentFiles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :document_files do |t|
+      t.string :attachment
+      t.string :file_name
+
+      t.timestamps
+    end
+
+    add_column :operator_documents, :document_file_id, :integer
+    add_index :operator_documents, :document_file_id
+  end
+end

--- a/db/migrate/20201023133947_migrate_operator_documents_to_files.rb
+++ b/db/migrate/20201023133947_migrate_operator_documents_to_files.rb
@@ -1,0 +1,5 @@
+class MigrateOperatorDocumentsToFiles < ActiveRecord::Migration[5.0]
+  def change
+    DocumentMigrationService.new(:attachments).call
+  end
+end

--- a/db/migrate/20201025124636_create_operator_document_histories.rb
+++ b/db/migrate/20201025124636_create_operator_document_histories.rb
@@ -3,6 +3,7 @@ class CreateOperatorDocumentHistories < ActiveRecord::Migration[5.0]
     create_table :operator_document_histories do |t|
       t.string :type
       t.date :expire_date
+      t.date :start_date
       t.integer :status
       t.integer :uploaded_by
       t.text :reason
@@ -11,16 +12,18 @@ class CreateOperatorDocumentHistories < ActiveRecord::Migration[5.0]
       t.boolean :public
       t.integer :source
       t.string :source_info
+      t.integer :fmu_id
+      t.integer :document_file_id
 
       t.timestamps
 
       t.references :operator_document, foreign_key: { on_delete: :cascade }, index: true
-      t.references :fmu, foreign_key: { on_delete: :cascade }, index: true
       t.references :operator, foreign_key: { on_delete: :cascade }, index: true
-      t.references :user, foreign_key: { on_delete: :cascade }, index: true
-      t.references :index_odh_on_rod_id, foreign_key: { to_table: :required_operator_documents, on_delete: :cascade }, index: true
-      t.references :document_file, foreign_key: { on_delete: :cascade }, index: true
+      t.references :user, foreign_key: { on_delete: :nullify }, index: true
+      t.references :required_operator_document, foreign_key: { on_delete: :cascade }, index: { name: 'index_odh_on_rod_id_id' }
 
+      t.index :fmu_id
+      t.index :document_file_id
       t.index :type
       t.index :expire_date
       t.index :status

--- a/db/migrate/20201025124636_create_operator_document_histories.rb
+++ b/db/migrate/20201025124636_create_operator_document_histories.rb
@@ -1,0 +1,32 @@
+class CreateOperatorDocumentHistories < ActiveRecord::Migration[5.0]
+  def change
+    create_table :operator_document_histories do |t|
+      t.string :type
+      t.date :expire_date
+      t.integer :status
+      t.integer :uploaded_by
+      t.text :reason
+      t.text :note
+      t.datetime :response_date
+      t.boolean :public
+      t.integer :source
+      t.string :source_info
+
+      t.timestamps
+
+      t.references :operator_document, foreign_key: { on_delete: :cascade }, index: true
+      t.references :fmu, foreign_key: { on_delete: :cascade }, index: true
+      t.references :operator, foreign_key: { on_delete: :cascade }, index: true
+      t.references :user, foreign_key: { on_delete: :cascade }, index: true
+      t.references :index_odh_on_rod_id, foreign_key: { to_table: :required_operator_documents, on_delete: :cascade }, index: true
+      t.references :document_file, foreign_key: { on_delete: :cascade }, index: true
+
+      t.index :type
+      t.index :expire_date
+      t.index :status
+      t.index :response_date
+      t.index :public
+      t.index :source
+    end
+  end
+end

--- a/db/migrate/20201025124636_create_operator_document_histories.rb
+++ b/db/migrate/20201025124636_create_operator_document_histories.rb
@@ -17,7 +17,7 @@ class CreateOperatorDocumentHistories < ActiveRecord::Migration[5.0]
 
       t.timestamps
 
-      t.references :operator_document, foreign_key: { on_delete: :cascade }, index: true
+      t.references :operator_document, foreign_key: { on_delete: :nullify }, index: true
       t.references :operator, foreign_key: { on_delete: :cascade }, index: true
       t.references :user, foreign_key: { on_delete: :nullify }, index: true
       t.references :required_operator_document, foreign_key: { on_delete: :cascade }, index: { name: 'index_odh_on_rod_id_id' }

--- a/db/migrate/20201025132137_change_operator_document_attachment_to_polymorphic.rb
+++ b/db/migrate/20201025132137_change_operator_document_attachment_to_polymorphic.rb
@@ -8,13 +8,14 @@ class ChangeOperatorDocumentAttachmentToPolymorphic < ActiveRecord::Migration[5.
         OperatorDocumentAnnex.unscoped.update_all documentable_type: 'OperatorDocument'
         OperatorDocumentAnnex.unscoped.update_all('documentable_id = operator_document_id')
 
-        add_index :operator_document_annexes, :documentable_type
-        add_index :operator_document_annexes, :documentable_id
+        add_index :operator_document_annexes, :documentable_type, where: 'documentable_type IS NOT NULL'
+        add_index :operator_document_annexes, :documentable_id, where: 'documentable_id IS NOT NULL'
         remove_column :operator_document_annexes, :operator_document_id
       end
 
       dir.down do
-        add_reference :operator_document_annexes, :operator_document_id, foreign_key: {on_delete: :cascade}, index: true
+        add_reference :operator_document_annexes,
+                      :operator_document, foreign_key: { on_delete: :cascade }, index: true
         OperatorDocumentAnnex.unscoped.update_all('operator_document_id = documentable_id')
 
         remove_column :operator_document_annexes, :documentable_id

--- a/db/migrate/20201025132137_change_operator_document_attachment_to_polymorphic.rb
+++ b/db/migrate/20201025132137_change_operator_document_attachment_to_polymorphic.rb
@@ -1,0 +1,25 @@
+class ChangeOperatorDocumentAttachmentToPolymorphic < ActiveRecord::Migration[5.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        add_column :operator_document_annexes, :documentable_id, :integer
+        add_column :operator_document_annexes, :documentable_type, :string
+
+        OperatorDocumentAnnex.unscoped.update_all documentable_type: 'OperatorDocument'
+        OperatorDocumentAnnex.unscoped.update_all('documentable_id = operator_document_id')
+
+        add_index :operator_document_annexes, :documentable_type
+        add_index :operator_document_annexes, :documentable_id
+        remove_column :operator_document_annexes, :operator_document_id
+      end
+
+      dir.down do
+        add_reference :operator_document_annexes, :operator_document_id, foreign_key: {on_delete: :cascade}, index: true
+        OperatorDocumentAnnex.unscoped.update_all('operator_document_id = documentable_id')
+
+        remove_column :operator_document_annexes, :documentable_id
+        remove_column :operator_document_annexes, :documentable_type
+      end
+    end
+  end
+end

--- a/db/migrate/20201025192229_change_operator_document_user_reference.rb
+++ b/db/migrate/20201025192229_change_operator_document_user_reference.rb
@@ -1,0 +1,5 @@
+class ChangeOperatorDocumentUserReference < ActiveRecord::Migration[5.0]
+  def change
+    add_foreign_key :operator_documents, :users, index: true, on_delete: :nullify
+  end
+end

--- a/db/migrate/20201025193753_copy_operator_documents_to_history.rb
+++ b/db/migrate/20201025193753_copy_operator_documents_to_history.rb
@@ -1,0 +1,6 @@
+class CopyOperatorDocumentsToHistory < ActiveRecord::Migration[5.0]
+  def change
+    DocumentMigrationService.new(:documents).call
+    remove_column :operator_documents, :current
+  end
+end

--- a/db/migrate/20201025193753_copy_operator_documents_to_history.rb
+++ b/db/migrate/20201025193753_copy_operator_documents_to_history.rb
@@ -1,6 +1,14 @@
 class CopyOperatorDocumentsToHistory < ActiveRecord::Migration[5.0]
   def change
-    DocumentMigrationService.new(:documents).call
-    remove_column :operator_documents, :current
+    reversible do |dir|
+      dir.up do
+        DocumentMigrationService.new(:documents).call
+        remove_column :operator_documents, :current
+      end
+      dir.down do
+        add_column :operator_documents, :current, :boolean, index: true
+      end
+    end
+
   end
 end

--- a/db/migrate/20201026084627_remove_attachment_from_operator_document.rb
+++ b/db/migrate/20201026084627_remove_attachment_from_operator_document.rb
@@ -1,0 +1,5 @@
+class RemoveAttachmentFromOperatorDocument < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :operator_documents, :attachment
+  end
+end

--- a/db/migrate/20201026084627_remove_attachment_from_operator_document.rb
+++ b/db/migrate/20201026084627_remove_attachment_from_operator_document.rb
@@ -1,5 +1,5 @@
 class RemoveAttachmentFromOperatorDocument < ActiveRecord::Migration[5.0]
   def change
-    remove_column :operator_documents, :attachment
+    remove_column :operator_documents, :attachment, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,17 @@ ActiveRecord::Schema.define(version: 20201026084627) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
   end
 
+  create_table "annex_documents", force: :cascade do |t|
+    t.string   "documentable_type",          null: false
+    t.integer  "documentable_id",            null: false
+    t.integer  "operator_document_annex_id", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.index ["documentable_id"], name: "index_annex_documents_on_documentable_id", using: :btree
+    t.index ["documentable_type"], name: "index_annex_documents_on_documentable_type", using: :btree
+    t.index ["operator_document_annex_id"], name: "index_annex_documents_on_operator_document_annex_id", using: :btree
+  end
+
   create_table "api_keys", force: :cascade do |t|
     t.string   "access_token"
     t.datetime "expires_at"
@@ -488,14 +499,10 @@ ActiveRecord::Schema.define(version: 20201026084627) do
     t.string   "attachment"
     t.integer  "uploaded_by"
     t.integer  "user_id"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.boolean  "public",            default: true, null: false
-    t.integer  "documentable_id"
-    t.string   "documentable_type"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "public",      default: true, null: false
     t.index ["deleted_at"], name: "index_operator_document_annexes_on_deleted_at", using: :btree
-    t.index ["documentable_id"], name: "index_operator_document_annexes_on_documentable_id", where: "(documentable_id IS NOT NULL)", using: :btree
-    t.index ["documentable_type"], name: "index_operator_document_annexes_on_documentable_type", where: "(documentable_type IS NOT NULL)", using: :btree
     t.index ["public"], name: "index_operator_document_annexes_on_public", using: :btree
     t.index ["status"], name: "index_operator_document_annexes_on_status", using: :btree
     t.index ["user_id"], name: "index_operator_document_annexes_on_user_id", using: :btree
@@ -930,6 +937,7 @@ ActiveRecord::Schema.define(version: 20201026084627) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
+  add_foreign_key "annex_documents", "operator_document_annexes", on_delete: :cascade
   add_foreign_key "api_keys", "users"
   add_foreign_key "comments", "users"
   add_foreign_key "country_links", "countries", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -546,7 +546,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.integer  "status"
     t.integer  "operator_id"
     t.string   "attachment"
-    t.boolean  "current"
     t.datetime "deleted_at"
     t.integer  "uploaded_by"
     t.integer  "user_id"
@@ -557,7 +556,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.integer  "source",                        default: 1
     t.string   "source_info"
     t.integer  "document_file_id"
-    t.index ["current"], name: "index_operator_documents_on_current", using: :btree
     t.index ["deleted_at"], name: "index_operator_documents_on_deleted_at", using: :btree
     t.index ["document_file_id"], name: "index_operator_documents_on_document_file_id", using: :btree
     t.index ["expire_date"], name: "index_operator_documents_on_expire_date", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201008122204) do
+ActiveRecord::Schema.define(version: 20201023133947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -317,6 +317,13 @@ ActiveRecord::Schema.define(version: 20201008122204) do
   create_table "direction_lookup", primary_key: "name", id: :string, limit: 20, force: :cascade do |t|
     t.string "abbrev", limit: 3
     t.index ["abbrev"], name: "direction_lookup_abbrev_idx", using: :btree
+  end
+
+  create_table "document_files", force: :cascade do |t|
+    t.string   "attachment"
+    t.string   "file_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "edges", primary_key: "gid", force: :cascade do |t|
@@ -847,8 +854,10 @@ ActiveRecord::Schema.define(version: 20201008122204) do
     t.boolean  "public",                        default: true, null: false
     t.integer  "source",                        default: 1
     t.string   "source_info"
+    t.integer  "document_file_id"
     t.index ["current"], name: "index_operator_documents_on_current", using: :btree
     t.index ["deleted_at"], name: "index_operator_documents_on_deleted_at", using: :btree
+    t.index ["document_file_id"], name: "index_operator_documents_on_document_file_id", using: :btree
     t.index ["expire_date"], name: "index_operator_documents_on_expire_date", using: :btree
     t.index ["fmu_id"], name: "index_operator_documents_on_fmu_id", using: :btree
     t.index ["operator_id"], name: "index_operator_documents_on_operator_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201023133947) do
+ActiveRecord::Schema.define(version: 20201025132137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -814,7 +814,6 @@ ActiveRecord::Schema.define(version: 20201023133947) do
   end
 
   create_table "operator_document_annexes", force: :cascade do |t|
-    t.integer  "operator_document_id"
     t.string   "name"
     t.date     "start_date"
     t.date     "expire_date"
@@ -823,14 +822,50 @@ ActiveRecord::Schema.define(version: 20201023133947) do
     t.string   "attachment"
     t.integer  "uploaded_by"
     t.integer  "user_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.boolean  "public",               default: true, null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.boolean  "public",            default: true, null: false
+    t.integer  "documentable_id"
+    t.string   "documentable_type"
     t.index ["deleted_at"], name: "index_operator_document_annexes_on_deleted_at", using: :btree
-    t.index ["operator_document_id"], name: "index_operator_document_annexes_on_operator_document_id", using: :btree
+    t.index ["documentable_id"], name: "index_operator_document_annexes_on_documentable_id", using: :btree
+    t.index ["documentable_type"], name: "index_operator_document_annexes_on_documentable_type", using: :btree
     t.index ["public"], name: "index_operator_document_annexes_on_public", using: :btree
     t.index ["status"], name: "index_operator_document_annexes_on_status", using: :btree
     t.index ["user_id"], name: "index_operator_document_annexes_on_user_id", using: :btree
+  end
+
+  create_table "operator_document_histories", force: :cascade do |t|
+    t.string   "type"
+    t.date     "expire_date"
+    t.integer  "status"
+    t.integer  "uploaded_by"
+    t.text     "reason"
+    t.text     "note"
+    t.datetime "response_date"
+    t.boolean  "public"
+    t.integer  "source"
+    t.string   "source_info"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "operator_document_id"
+    t.integer  "fmu_id"
+    t.integer  "operator_id"
+    t.integer  "user_id"
+    t.integer  "index_odh_on_rod_id_id"
+    t.integer  "document_file_id"
+    t.index ["document_file_id"], name: "index_operator_document_histories_on_document_file_id", using: :btree
+    t.index ["expire_date"], name: "index_operator_document_histories_on_expire_date", using: :btree
+    t.index ["fmu_id"], name: "index_operator_document_histories_on_fmu_id", using: :btree
+    t.index ["index_odh_on_rod_id_id"], name: "index_operator_document_histories_on_index_odh_on_rod_id_id", using: :btree
+    t.index ["operator_document_id"], name: "index_operator_document_histories_on_operator_document_id", using: :btree
+    t.index ["operator_id"], name: "index_operator_document_histories_on_operator_id", using: :btree
+    t.index ["public"], name: "index_operator_document_histories_on_public", using: :btree
+    t.index ["response_date"], name: "index_operator_document_histories_on_response_date", using: :btree
+    t.index ["source"], name: "index_operator_document_histories_on_source", using: :btree
+    t.index ["status"], name: "index_operator_document_histories_on_status", using: :btree
+    t.index ["type"], name: "index_operator_document_histories_on_type", using: :btree
+    t.index ["user_id"], name: "index_operator_document_histories_on_user_id", using: :btree
   end
 
   create_table "operator_documents", force: :cascade do |t|
@@ -1442,6 +1477,12 @@ ActiveRecord::Schema.define(version: 20201023133947) do
   add_foreign_key "observations", "observation_reports"
   add_foreign_key "observations", "operators"
   add_foreign_key "observations", "users"
+  add_foreign_key "operator_document_histories", "document_files", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "fmus", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "operator_documents", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "operators", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "required_operator_documents", column: "index_odh_on_rod_id_id", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "users", on_delete: :cascade
   add_foreign_key "operator_documents", "fmus"
   add_foreign_key "operator_documents", "operators"
   add_foreign_key "operator_documents", "required_operator_documents"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201025132137) do
+ActiveRecord::Schema.define(version: 20201025193753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -828,8 +828,8 @@ ActiveRecord::Schema.define(version: 20201025132137) do
     t.integer  "documentable_id"
     t.string   "documentable_type"
     t.index ["deleted_at"], name: "index_operator_document_annexes_on_deleted_at", using: :btree
-    t.index ["documentable_id"], name: "index_operator_document_annexes_on_documentable_id", using: :btree
-    t.index ["documentable_type"], name: "index_operator_document_annexes_on_documentable_type", using: :btree
+    t.index ["documentable_id"], name: "index_operator_document_annexes_on_documentable_id", where: "(documentable_id IS NOT NULL)", using: :btree
+    t.index ["documentable_type"], name: "index_operator_document_annexes_on_documentable_type", where: "(documentable_type IS NOT NULL)", using: :btree
     t.index ["public"], name: "index_operator_document_annexes_on_public", using: :btree
     t.index ["status"], name: "index_operator_document_annexes_on_status", using: :btree
     t.index ["user_id"], name: "index_operator_document_annexes_on_user_id", using: :btree
@@ -838,6 +838,7 @@ ActiveRecord::Schema.define(version: 20201025132137) do
   create_table "operator_document_histories", force: :cascade do |t|
     t.string   "type"
     t.date     "expire_date"
+    t.date     "start_date"
     t.integer  "status"
     t.integer  "uploaded_by"
     t.text     "reason"
@@ -846,21 +847,21 @@ ActiveRecord::Schema.define(version: 20201025132137) do
     t.boolean  "public"
     t.integer  "source"
     t.string   "source_info"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "operator_document_id"
     t.integer  "fmu_id"
+    t.integer  "document_file_id"
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "operator_document_id"
     t.integer  "operator_id"
     t.integer  "user_id"
-    t.integer  "index_odh_on_rod_id_id"
-    t.integer  "document_file_id"
+    t.integer  "required_operator_document_id"
     t.index ["document_file_id"], name: "index_operator_document_histories_on_document_file_id", using: :btree
     t.index ["expire_date"], name: "index_operator_document_histories_on_expire_date", using: :btree
     t.index ["fmu_id"], name: "index_operator_document_histories_on_fmu_id", using: :btree
-    t.index ["index_odh_on_rod_id_id"], name: "index_operator_document_histories_on_index_odh_on_rod_id_id", using: :btree
     t.index ["operator_document_id"], name: "index_operator_document_histories_on_operator_document_id", using: :btree
     t.index ["operator_id"], name: "index_operator_document_histories_on_operator_id", using: :btree
     t.index ["public"], name: "index_operator_document_histories_on_public", using: :btree
+    t.index ["required_operator_document_id"], name: "index_odh_on_rod_id_id", using: :btree
     t.index ["response_date"], name: "index_operator_document_histories_on_response_date", using: :btree
     t.index ["source"], name: "index_operator_document_histories_on_source", using: :btree
     t.index ["status"], name: "index_operator_document_histories_on_status", using: :btree
@@ -879,7 +880,6 @@ ActiveRecord::Schema.define(version: 20201025132137) do
     t.integer  "status"
     t.integer  "operator_id"
     t.string   "attachment"
-    t.boolean  "current"
     t.datetime "deleted_at"
     t.integer  "uploaded_by"
     t.integer  "user_id"
@@ -890,7 +890,6 @@ ActiveRecord::Schema.define(version: 20201025132137) do
     t.integer  "source",                        default: 1
     t.string   "source_info"
     t.integer  "document_file_id"
-    t.index ["current"], name: "index_operator_documents_on_current", using: :btree
     t.index ["deleted_at"], name: "index_operator_documents_on_deleted_at", using: :btree
     t.index ["document_file_id"], name: "index_operator_documents_on_document_file_id", using: :btree
     t.index ["expire_date"], name: "index_operator_documents_on_expire_date", using: :btree
@@ -1477,15 +1476,14 @@ ActiveRecord::Schema.define(version: 20201025132137) do
   add_foreign_key "observations", "observation_reports"
   add_foreign_key "observations", "operators"
   add_foreign_key "observations", "users"
-  add_foreign_key "operator_document_histories", "document_files", on_delete: :cascade
-  add_foreign_key "operator_document_histories", "fmus", on_delete: :cascade
   add_foreign_key "operator_document_histories", "operator_documents", on_delete: :cascade
   add_foreign_key "operator_document_histories", "operators", on_delete: :cascade
-  add_foreign_key "operator_document_histories", "required_operator_documents", column: "index_odh_on_rod_id_id", on_delete: :cascade
-  add_foreign_key "operator_document_histories", "users", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "required_operator_documents", on_delete: :cascade
+  add_foreign_key "operator_document_histories", "users", on_delete: :nullify
   add_foreign_key "operator_documents", "fmus"
   add_foreign_key "operator_documents", "operators"
   add_foreign_key "operator_documents", "required_operator_documents"
+  add_foreign_key "operator_documents", "users", on_delete: :nullify
   add_foreign_key "photos", "users"
   add_foreign_key "ranking_operator_documents", "countries", on_delete: :cascade
   add_foreign_key "ranking_operator_documents", "operators", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,11 +14,11 @@ ActiveRecord::Schema.define(version: 20201025193753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
   enable_extension "address_standardizer"
   enable_extension "address_standardizer_data_us"
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
-  enable_extension "postgis"
   enable_extension "postgis_tiger_geocoder"
   enable_extension "postgis_topology"
 
@@ -36,55 +36,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
   end
 
-  create_table "addr", primary_key: "gid", force: :cascade do |t|
-    t.bigint  "tlid"
-    t.string  "fromhn",    limit: 12
-    t.string  "tohn",      limit: 12
-    t.string  "side",      limit: 1
-    t.string  "zip",       limit: 5
-    t.string  "plus4",     limit: 4
-    t.string  "fromtyp",   limit: 1
-    t.string  "totyp",     limit: 1
-    t.integer "fromarmid"
-    t.integer "toarmid"
-    t.string  "arid",      limit: 22
-    t.string  "mtfcc",     limit: 5
-    t.string  "statefp",   limit: 2
-    t.index ["tlid", "statefp"], name: "idx_tiger_addr_tlid_statefp", using: :btree
-    t.index ["zip"], name: "idx_tiger_addr_zip", using: :btree
-  end
-
-  create_table "addrfeat", primary_key: "gid", force: :cascade do |t|
-    t.bigint   "tlid"
-    t.string   "statefp",    limit: 2,                                   null: false
-    t.string   "aridl",      limit: 22
-    t.string   "aridr",      limit: 22
-    t.string   "linearid",   limit: 22
-    t.string   "fullname",   limit: 100
-    t.string   "lfromhn",    limit: 12
-    t.string   "ltohn",      limit: 12
-    t.string   "rfromhn",    limit: 12
-    t.string   "rtohn",      limit: 12
-    t.string   "zipl",       limit: 5
-    t.string   "zipr",       limit: 5
-    t.string   "edge_mtfcc", limit: 5
-    t.string   "parityl",    limit: 1
-    t.string   "parityr",    limit: 1
-    t.string   "plus4l",     limit: 4
-    t.string   "plus4r",     limit: 4
-    t.string   "lfromtyp",   limit: 1
-    t.string   "ltotyp",     limit: 1
-    t.string   "rfromtyp",   limit: 1
-    t.string   "rtotyp",     limit: 1
-    t.string   "offsetl",    limit: 1
-    t.string   "offsetr",    limit: 1
-    t.geometry "the_geom",   limit: {:srid=>4269, :type=>"line_string"}
-    t.index ["the_geom"], name: "idx_addrfeat_geom_gist", using: :gist
-    t.index ["tlid"], name: "idx_addrfeat_tlid", using: :btree
-    t.index ["zipl"], name: "idx_addrfeat_zipl", using: :btree
-    t.index ["zipr"], name: "idx_addrfeat_zipr", using: :btree
-  end
-
   create_table "api_keys", force: :cascade do |t|
     t.string   "access_token"
     t.datetime "expires_at"
@@ -94,27 +45,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.datetime "updated_at",                  null: false
     t.index ["access_token"], name: "index_api_keys_on_access_token", unique: true, using: :btree
     t.index ["user_id"], name: "index_api_keys_on_user_id", using: :btree
-  end
-
-  create_table "barfoos", id: false, force: :cascade do |t|
-    t.text    "name"
-    t.integer "rank"
-  end
-
-  create_table "bg", primary_key: "bg_id", id: :string, limit: 12, force: :cascade, comment: "block groups" do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2
-    t.string   "countyfp", limit: 3
-    t.string   "tractce",  limit: 6
-    t.string   "blkgrpce", limit: 1
-    t.string   "namelsad", limit: 13
-    t.string   "mtfcc",    limit: 5
-    t.string   "funcstat", limit: 1
-    t.float    "aland"
-    t.float    "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
   end
 
   create_table "categories", force: :cascade do |t|
@@ -247,196 +177,11 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["country_id"], name: "index_country_vpas_on_country_id", using: :btree
   end
 
-  create_table "county", primary_key: "cntyidfp", id: :string, limit: 5, force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2
-    t.string   "countyfp", limit: 3
-    t.string   "countyns", limit: 8
-    t.string   "name",     limit: 100
-    t.string   "namelsad", limit: 100
-    t.string   "lsad",     limit: 2
-    t.string   "classfp",  limit: 2
-    t.string   "mtfcc",    limit: 5
-    t.string   "csafp",    limit: 3
-    t.string   "cbsafp",   limit: 5
-    t.string   "metdivfp", limit: 5
-    t.string   "funcstat", limit: 1
-    t.bigint   "aland"
-    t.float    "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["countyfp"], name: "idx_tiger_county", using: :btree
-    t.index ["gid"], name: "uidx_county_gid", unique: true, using: :btree
-  end
-
-  create_table "county_lookup", primary_key: ["st_code", "co_code"], force: :cascade do |t|
-    t.integer "st_code",            null: false
-    t.string  "state",   limit: 2
-    t.integer "co_code",            null: false
-    t.string  "name",    limit: 90
-    t.index "soundex((name)::text)", name: "county_lookup_name_idx", using: :btree
-    t.index ["state"], name: "county_lookup_state_idx", using: :btree
-  end
-
-  create_table "countysub_lookup", primary_key: ["st_code", "co_code", "cs_code"], force: :cascade do |t|
-    t.integer "st_code",            null: false
-    t.string  "state",   limit: 2
-    t.integer "co_code",            null: false
-    t.string  "county",  limit: 90
-    t.integer "cs_code",            null: false
-    t.string  "name",    limit: 90
-    t.index "soundex((name)::text)", name: "countysub_lookup_name_idx", using: :btree
-    t.index ["state"], name: "countysub_lookup_state_idx", using: :btree
-  end
-
-  create_table "cousub", primary_key: "cosbidfp", id: :string, limit: 10, force: :cascade do |t|
-    t.serial   "gid",                                                                   null: false
-    t.string   "statefp",  limit: 2
-    t.string   "countyfp", limit: 3
-    t.string   "cousubfp", limit: 5
-    t.string   "cousubns", limit: 8
-    t.string   "name",     limit: 100
-    t.string   "namelsad", limit: 100
-    t.string   "lsad",     limit: 2
-    t.string   "classfp",  limit: 2
-    t.string   "mtfcc",    limit: 5
-    t.string   "cnectafp", limit: 3
-    t.string   "nectafp",  limit: 5
-    t.string   "nctadvfp", limit: 5
-    t.string   "funcstat", limit: 1
-    t.decimal  "aland",                                                  precision: 14
-    t.decimal  "awater",                                                 precision: 14
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["gid"], name: "uidx_cousub_gid", unique: true, using: :btree
-    t.index ["the_geom"], name: "tige_cousub_the_geom_gist", using: :gist
-  end
-
-  create_table "direction_lookup", primary_key: "name", id: :string, limit: 20, force: :cascade do |t|
-    t.string "abbrev", limit: 3
-    t.index ["abbrev"], name: "direction_lookup_abbrev_idx", using: :btree
-  end
-
   create_table "document_files", force: :cascade do |t|
     t.string   "attachment"
     t.string   "file_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "edges", primary_key: "gid", force: :cascade do |t|
-    t.string   "statefp",    limit: 2
-    t.string   "countyfp",   limit: 3
-    t.bigint   "tlid"
-    t.decimal  "tfidl",                                                        precision: 10
-    t.decimal  "tfidr",                                                        precision: 10
-    t.string   "mtfcc",      limit: 5
-    t.string   "fullname",   limit: 100
-    t.string   "smid",       limit: 22
-    t.string   "lfromadd",   limit: 12
-    t.string   "ltoadd",     limit: 12
-    t.string   "rfromadd",   limit: 12
-    t.string   "rtoadd",     limit: 12
-    t.string   "zipl",       limit: 5
-    t.string   "zipr",       limit: 5
-    t.string   "featcat",    limit: 1
-    t.string   "hydroflg",   limit: 1
-    t.string   "railflg",    limit: 1
-    t.string   "roadflg",    limit: 1
-    t.string   "olfflg",     limit: 1
-    t.string   "passflg",    limit: 1
-    t.string   "divroad",    limit: 1
-    t.string   "exttyp",     limit: 1
-    t.string   "ttyp",       limit: 1
-    t.string   "deckedroad", limit: 1
-    t.string   "artpath",    limit: 1
-    t.string   "persist",    limit: 1
-    t.string   "gcseflg",    limit: 1
-    t.string   "offsetl",    limit: 1
-    t.string   "offsetr",    limit: 1
-    t.decimal  "tnidf",                                                        precision: 10
-    t.decimal  "tnidt",                                                        precision: 10
-    t.geometry "the_geom",   limit: {:srid=>4269, :type=>"multi_line_string"}
-    t.index ["countyfp"], name: "idx_tiger_edges_countyfp", using: :btree
-    t.index ["the_geom"], name: "idx_tiger_edges_the_geom_gist", using: :gist
-    t.index ["tlid"], name: "idx_edges_tlid", using: :btree
-  end
-
-  create_table "faces", primary_key: "gid", force: :cascade do |t|
-    t.decimal  "tfid",                                                     precision: 10
-    t.string   "statefp00",  limit: 2
-    t.string   "countyfp00", limit: 3
-    t.string   "tractce00",  limit: 6
-    t.string   "blkgrpce00", limit: 1
-    t.string   "blockce00",  limit: 4
-    t.string   "cousubfp00", limit: 5
-    t.string   "submcdfp00", limit: 5
-    t.string   "conctyfp00", limit: 5
-    t.string   "placefp00",  limit: 5
-    t.string   "aiannhfp00", limit: 5
-    t.string   "aiannhce00", limit: 4
-    t.string   "comptyp00",  limit: 1
-    t.string   "trsubfp00",  limit: 5
-    t.string   "trsubce00",  limit: 3
-    t.string   "anrcfp00",   limit: 5
-    t.string   "elsdlea00",  limit: 5
-    t.string   "scsdlea00",  limit: 5
-    t.string   "unsdlea00",  limit: 5
-    t.string   "uace00",     limit: 5
-    t.string   "cd108fp",    limit: 2
-    t.string   "sldust00",   limit: 3
-    t.string   "sldlst00",   limit: 3
-    t.string   "vtdst00",    limit: 6
-    t.string   "zcta5ce00",  limit: 5
-    t.string   "tazce00",    limit: 6
-    t.string   "ugace00",    limit: 5
-    t.string   "puma5ce00",  limit: 5
-    t.string   "statefp",    limit: 2
-    t.string   "countyfp",   limit: 3
-    t.string   "tractce",    limit: 6
-    t.string   "blkgrpce",   limit: 1
-    t.string   "blockce",    limit: 4
-    t.string   "cousubfp",   limit: 5
-    t.string   "submcdfp",   limit: 5
-    t.string   "conctyfp",   limit: 5
-    t.string   "placefp",    limit: 5
-    t.string   "aiannhfp",   limit: 5
-    t.string   "aiannhce",   limit: 4
-    t.string   "comptyp",    limit: 1
-    t.string   "trsubfp",    limit: 5
-    t.string   "trsubce",    limit: 3
-    t.string   "anrcfp",     limit: 5
-    t.string   "ttractce",   limit: 6
-    t.string   "tblkgpce",   limit: 1
-    t.string   "elsdlea",    limit: 5
-    t.string   "scsdlea",    limit: 5
-    t.string   "unsdlea",    limit: 5
-    t.string   "uace",       limit: 5
-    t.string   "cd111fp",    limit: 2
-    t.string   "sldust",     limit: 3
-    t.string   "sldlst",     limit: 3
-    t.string   "vtdst",      limit: 6
-    t.string   "zcta5ce",    limit: 5
-    t.string   "tazce",      limit: 6
-    t.string   "ugace",      limit: 5
-    t.string   "puma5ce",    limit: 5
-    t.string   "csafp",      limit: 3
-    t.string   "cbsafp",     limit: 5
-    t.string   "metdivfp",   limit: 5
-    t.string   "cnectafp",   limit: 3
-    t.string   "nectafp",    limit: 5
-    t.string   "nctadvfp",   limit: 5
-    t.string   "lwflag",     limit: 1
-    t.string   "offset",     limit: 1
-    t.float    "atotal"
-    t.string   "intptlat",   limit: 11
-    t.string   "intptlon",   limit: 12
-    t.geometry "the_geom",   limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["countyfp"], name: "idx_tiger_faces_countyfp", using: :btree
-    t.index ["tfid"], name: "idx_tiger_faces_tfid", using: :btree
-    t.index ["the_geom"], name: "tiger_faces_the_geom_gist", using: :gist
   end
 
   create_table "faq_translations", force: :cascade do |t|
@@ -455,31 +200,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "image"
-  end
-
-  create_table "featnames", primary_key: "gid", force: :cascade do |t|
-    t.bigint "tlid"
-    t.string "fullname",   limit: 100
-    t.string "name",       limit: 100
-    t.string "predirabrv", limit: 15
-    t.string "pretypabrv", limit: 50
-    t.string "prequalabr", limit: 15
-    t.string "sufdirabrv", limit: 15
-    t.string "suftypabrv", limit: 50
-    t.string "sufqualabr", limit: 15
-    t.string "predir",     limit: 2
-    t.string "pretyp",     limit: 3
-    t.string "prequal",    limit: 2
-    t.string "sufdir",     limit: 2
-    t.string "suftyp",     limit: 3
-    t.string "sufqual",    limit: 2
-    t.string "linearid",   limit: 22
-    t.string "mtfcc",      limit: 5
-    t.string "paflag",     limit: 1
-    t.string "statefp",    limit: 2
-    t.index "lower((name)::text)", name: "idx_tiger_featnames_lname", using: :btree
-    t.index "soundex((name)::text)", name: "idx_tiger_featnames_snd_name", using: :btree
-    t.index ["tlid", "statefp"], name: "idx_tiger_featnames_tlid_statefp", using: :btree
   end
 
   create_table "fmu_operators", force: :cascade do |t|
@@ -525,25 +245,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["country_id"], name: "index_fmus_on_country_id", using: :btree
     t.index ["deleted_at"], name: "index_fmus_on_deleted_at", using: :btree
     t.index ["forest_type"], name: "index_fmus_on_forest_type", using: :btree
-  end
-
-  create_table "foobars", id: false, force: :cascade do |t|
-    t.text    "name"
-    t.integer "value"
-  end
-
-  create_table "geocode_settings", primary_key: "name", id: :text, force: :cascade do |t|
-    t.text "setting"
-    t.text "unit"
-    t.text "category"
-    t.text "short_desc"
-  end
-
-  create_table "geocode_settings_default", primary_key: "name", id: :text, force: :cascade do |t|
-    t.text "setting"
-    t.text "unit"
-    t.text "category"
-    t.text "short_desc"
   end
 
   create_table "gov_documents", force: :cascade do |t|
@@ -639,41 +340,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.string   "currency"
     t.index ["country_id"], name: "index_laws_on_country_id", using: :btree
     t.index ["subcategory_id"], name: "index_laws_on_subcategory_id", using: :btree
-  end
-
-  create_table "loader_lookuptables", primary_key: "lookup_name", id: :text, comment: "This is the table name to inherit from and suffix of resulting output table -- how the table will be named --  edges here would mean -- ma_edges , pa_edges etc. except in the case of national tables. national level tables have no prefix", force: :cascade do |t|
-    t.integer "process_order",                   default: 1000,  null: false
-    t.text    "table_name",                                                   comment: "suffix of the tables to load e.g.  edges would load all tables like *edges.dbf(shp)  -- so tl_2010_42129_edges.dbf .  "
-    t.boolean "single_mode",                     default: true,  null: false
-    t.boolean "load",                            default: true,  null: false, comment: "Whether or not to load the table.  For states and zcta5 (you may just want to download states10, zcta510 nationwide file manually) load your own into a single table that inherits from tiger.states, tiger.zcta5.  You'll get improved performance for some geocoding cases."
-    t.boolean "level_county",                    default: false, null: false
-    t.boolean "level_state",                     default: false, null: false
-    t.boolean "level_nation",                    default: false, null: false, comment: "These are tables that contain all data for the whole US so there is just a single file"
-    t.text    "post_load_process"
-    t.boolean "single_geom_mode",                default: false
-    t.string  "insert_mode",           limit: 1, default: "c",   null: false
-    t.text    "pre_load_process"
-    t.text    "columns_exclude",                                              comment: "List of columns to exclude as an array. This is excluded from both input table and output table and rest of columns remaining are assumed to be in same order in both tables. gid, geoid,cpi,suffix1ce are excluded if no columns are specified.",                              array: true
-    t.text    "website_root_override",                                        comment: "Path to use for wget instead of that specified in year table.  Needed currently for zcta where they release that only for 2000 and 2010"
-  end
-
-  create_table "loader_platform", primary_key: "os", id: :string, limit: 50, force: :cascade do |t|
-    t.text "declare_sect"
-    t.text "pgbin"
-    t.text "wget"
-    t.text "unzip_command"
-    t.text "psql"
-    t.text "path_sep"
-    t.text "loader"
-    t.text "environ_set_command"
-    t.text "county_process_command"
-  end
-
-  create_table "loader_variables", primary_key: "tiger_year", id: :string, limit: 4, force: :cascade do |t|
-    t.text "website_root"
-    t.text "staging_fold"
-    t.text "data_schema"
-    t.text "staging_schema"
   end
 
   create_table "observation_documents", force: :cascade do |t|
@@ -880,6 +546,7 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.integer  "status"
     t.integer  "operator_id"
     t.string   "attachment"
+    t.boolean  "current"
     t.datetime "deleted_at"
     t.integer  "uploaded_by"
     t.integer  "user_id"
@@ -890,6 +557,7 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.integer  "source",                        default: 1
     t.string   "source_info"
     t.integer  "document_file_id"
+    t.index ["current"], name: "index_operator_documents_on_current", using: :btree
     t.index ["deleted_at"], name: "index_operator_documents_on_deleted_at", using: :btree
     t.index ["document_file_id"], name: "index_operator_documents_on_document_file_id", using: :btree
     t.index ["expire_date"], name: "index_operator_documents_on_expire_date", using: :btree
@@ -934,27 +602,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["is_active"], name: "index_operators_on_is_active", using: :btree
   end
 
-  create_table "pagc_gaz", force: :cascade do |t|
-    t.integer "seq"
-    t.text    "word"
-    t.text    "stdword"
-    t.integer "token"
-    t.boolean "is_custom", default: true, null: false
-  end
-
-  create_table "pagc_lex", force: :cascade do |t|
-    t.integer "seq"
-    t.text    "word"
-    t.text    "stdword"
-    t.integer "token"
-    t.boolean "is_custom", default: true, null: false
-  end
-
-  create_table "pagc_rules", force: :cascade do |t|
-    t.text    "rule"
-    t.boolean "is_custom", default: true
-  end
-
   create_table "photos", force: :cascade do |t|
     t.string   "name"
     t.string   "attachment"
@@ -964,38 +611,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.datetime "updated_at",       null: false
     t.integer  "user_id"
     t.index ["attacheable_id", "attacheable_type"], name: "photos_attacheable_index", using: :btree
-  end
-
-  create_table "place", primary_key: "plcidfp", id: :string, limit: 7, force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2
-    t.string   "placefp",  limit: 5
-    t.string   "placens",  limit: 8
-    t.string   "name",     limit: 100
-    t.string   "namelsad", limit: 100
-    t.string   "lsad",     limit: 2
-    t.string   "classfp",  limit: 2
-    t.string   "cpi",      limit: 1
-    t.string   "pcicbsa",  limit: 1
-    t.string   "pcinecta", limit: 1
-    t.string   "mtfcc",    limit: 5
-    t.string   "funcstat", limit: 1
-    t.bigint   "aland"
-    t.bigint   "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["gid"], name: "uidx_tiger_place_gid", unique: true, using: :btree
-    t.index ["the_geom"], name: "tiger_place_the_geom_gist", using: :gist
-  end
-
-  create_table "place_lookup", primary_key: ["st_code", "pl_code"], force: :cascade do |t|
-    t.integer "st_code",            null: false
-    t.string  "state",   limit: 2
-    t.integer "pl_code",            null: false
-    t.string  "name",    limit: 90
-    t.index "soundex((name)::text)", name: "place_lookup_name_idx", using: :btree
-    t.index ["state"], name: "place_lookup_state_idx", using: :btree
   end
 
   create_table "ranking_operator_documents", force: :cascade do |t|
@@ -1144,11 +759,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["operator_id"], name: "index_score_operator_observations_on_operator_id", using: :btree
   end
 
-  create_table "secondary_unit_lookup", primary_key: "name", id: :string, limit: 20, force: :cascade do |t|
-    t.string "abbrev", limit: 5
-    t.index ["abbrev"], name: "secondary_unit_lookup_abbrev_idx", using: :btree
-  end
-
   create_table "severities", force: :cascade do |t|
     t.integer  "level"
     t.datetime "created_at",     null: false
@@ -1210,41 +820,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["species_id"], name: "index_species_translations_on_species_id", using: :btree
   end
 
-  create_table "state", primary_key: "statefp", id: :string, limit: 2, force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "region",   limit: 2
-    t.string   "division", limit: 2
-    t.string   "statens",  limit: 8
-    t.string   "stusps",   limit: 2,                                     null: false
-    t.string   "name",     limit: 100
-    t.string   "lsad",     limit: 2
-    t.string   "mtfcc",    limit: 5
-    t.string   "funcstat", limit: 1
-    t.bigint   "aland"
-    t.bigint   "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["gid"], name: "uidx_tiger_state_gid", unique: true, using: :btree
-    t.index ["stusps"], name: "uidx_tiger_state_stusps", unique: true, using: :btree
-    t.index ["the_geom"], name: "idx_tiger_state_the_geom_gist", using: :gist
-  end
-
-  create_table "state_lookup", primary_key: "st_code", id: :integer, force: :cascade do |t|
-    t.string "name",    limit: 40
-    t.string "abbrev",  limit: 3
-    t.string "statefp", limit: 2
-    t.index ["abbrev"], name: "state_lookup_abbrev_key", unique: true, using: :btree
-    t.index ["name"], name: "state_lookup_name_key", unique: true, using: :btree
-    t.index ["statefp"], name: "state_lookup_statefp_key", unique: true, using: :btree
-  end
-
-  create_table "street_type_lookup", primary_key: "name", id: :string, limit: 50, force: :cascade do |t|
-    t.string  "abbrev", limit: 50
-    t.boolean "is_hw",             default: false, null: false
-    t.index ["abbrev"], name: "street_type_lookup_abbrev_idx", using: :btree
-  end
-
   create_table "subcategories", force: :cascade do |t|
     t.integer  "category_id"
     t.integer  "subcategory_type"
@@ -1266,24 +841,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["subcategory_id"], name: "index_subcategory_translations_on_subcategory_id", using: :btree
   end
 
-  create_table "tabblock", primary_key: "tabblock_id", id: :string, limit: 16, force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2
-    t.string   "countyfp", limit: 3
-    t.string   "tractce",  limit: 6
-    t.string   "blockce",  limit: 4
-    t.string   "name",     limit: 20
-    t.string   "mtfcc",    limit: 5
-    t.string   "ur",       limit: 1
-    t.string   "uace",     limit: 5
-    t.string   "funcstat", limit: 1
-    t.float    "aland"
-    t.float    "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-  end
-
   create_table "tool_translations", force: :cascade do |t|
     t.integer  "tool_id",     null: false
     t.string   "locale",      null: false
@@ -1299,22 +856,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.integer  "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "tract", primary_key: "tract_id", id: :string, limit: 11, force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2
-    t.string   "countyfp", limit: 3
-    t.string   "tractce",  limit: 6
-    t.string   "name",     limit: 7
-    t.string   "namelsad", limit: 20
-    t.string   "mtfcc",    limit: 5
-    t.string   "funcstat", limit: 1
-    t.float    "aland"
-    t.float    "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
   end
 
   create_table "tutorial_translations", force: :cascade do |t|
@@ -1392,67 +933,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
-  create_table "zcta5", primary_key: ["zcta5ce", "statefp"], force: :cascade do |t|
-    t.serial   "gid",                                                    null: false
-    t.string   "statefp",  limit: 2,                                     null: false
-    t.string   "zcta5ce",  limit: 5,                                     null: false
-    t.string   "classfp",  limit: 2
-    t.string   "mtfcc",    limit: 5
-    t.string   "funcstat", limit: 1
-    t.float    "aland"
-    t.float    "awater"
-    t.string   "intptlat", limit: 11
-    t.string   "intptlon", limit: 12
-    t.string   "partflg",  limit: 1
-    t.geometry "the_geom", limit: {:srid=>4269, :type=>"multi_polygon"}
-    t.index ["gid"], name: "uidx_tiger_zcta5_gid", unique: true, using: :btree
-  end
-
-  create_table "zip_lookup", primary_key: "zip", id: :integer, force: :cascade do |t|
-    t.integer "st_code"
-    t.string  "state",   limit: 2
-    t.integer "co_code"
-    t.string  "county",  limit: 90
-    t.integer "cs_code"
-    t.string  "cousub",  limit: 90
-    t.integer "pl_code"
-    t.string  "place",   limit: 90
-    t.integer "cnt"
-  end
-
-  create_table "zip_lookup_all", id: false, force: :cascade do |t|
-    t.integer "zip"
-    t.integer "st_code"
-    t.string  "state",   limit: 2
-    t.integer "co_code"
-    t.string  "county",  limit: 90
-    t.integer "cs_code"
-    t.string  "cousub",  limit: 90
-    t.integer "pl_code"
-    t.string  "place",   limit: 90
-    t.integer "cnt"
-  end
-
-  create_table "zip_lookup_base", primary_key: "zip", id: :string, limit: 5, force: :cascade do |t|
-    t.string "state",   limit: 40
-    t.string "county",  limit: 90
-    t.string "city",    limit: 90
-    t.string "statefp", limit: 2
-  end
-
-  create_table "zip_state", primary_key: ["zip", "stusps"], force: :cascade do |t|
-    t.string "zip",     limit: 5, null: false
-    t.string "stusps",  limit: 2, null: false
-    t.string "statefp", limit: 2
-  end
-
-  create_table "zip_state_loc", primary_key: ["zip", "stusps", "place"], force: :cascade do |t|
-    t.string "zip",     limit: 5,   null: false
-    t.string "stusps",  limit: 2,   null: false
-    t.string "statefp", limit: 2
-    t.string "place",   limit: 100, null: false
-  end
-
   add_foreign_key "api_keys", "users"
   add_foreign_key "comments", "users"
   add_foreign_key "country_links", "countries", on_delete: :cascade
@@ -1476,7 +956,8 @@ ActiveRecord::Schema.define(version: 20201025193753) do
   add_foreign_key "observations", "observation_reports"
   add_foreign_key "observations", "operators"
   add_foreign_key "observations", "users"
-  add_foreign_key "operator_document_histories", "operator_documents", on_delete: :cascade
+  add_foreign_key "observations", "users", column: "modified_user_id"
+  add_foreign_key "operator_document_histories", "operator_documents", on_delete: :nullify
   add_foreign_key "operator_document_histories", "operators", on_delete: :cascade
   add_foreign_key "operator_document_histories", "required_operator_documents", on_delete: :cascade
   add_foreign_key "operator_document_histories", "users", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201025193753) do
+ActiveRecord::Schema.define(version: 20201026084627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -545,7 +545,6 @@ ActiveRecord::Schema.define(version: 20201025193753) do
     t.datetime "updated_at",                                   null: false
     t.integer  "status"
     t.integer  "operator_id"
-    t.string   "attachment"
     t.datetime "deleted_at"
     t.integer  "uploaded_by"
     t.integer  "user_id"

--- a/spec/factories/document_file.rb
+++ b/spec/factories/document_file.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: document_files
+#
+#  id         :integer          not null, primary key
+#  attachment :string
+#  file_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :document_file do
+    file_name { 'image'}
+    attachment { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files', 'image.png')) }
+  end
+end

--- a/spec/factories/operator_document_annexes.rb
+++ b/spec/factories/operator_document_annexes.rb
@@ -2,20 +2,18 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                :integer          not null, primary key
-#  name              :string
-#  start_date        :date
-#  expire_date       :date
-#  deleted_at        :date
-#  status            :integer
-#  attachment        :string
-#  uploaded_by       :integer
-#  user_id           :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  public            :boolean          default("true"), not null
-#  documentable_id   :integer
-#  documentable_type :string
+#  id          :integer          not null, primary key
+#  name        :string
+#  start_date  :date
+#  expire_date :date
+#  deleted_at  :date
+#  status      :integer
+#  attachment  :string
+#  uploaded_by :integer
+#  user_id     :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  public      :boolean          default("true"), not null
 #
 
 FactoryBot.define do
@@ -23,9 +21,13 @@ FactoryBot.define do
     start_date { Date.yesterday }
     expire_date { Date.tomorrow }
 
-    after(:build) do |random_operator_document_annex|
-      random_operator_document_annex.operator_document ||=
-        FactoryBot.create :operator_document
+    after(:create) do |random_operator_document_annex|
+      if random_operator_document_annex.documentables.none?
+        od = FactoryBot.create :operator_document_country
+        AnnexDocument.create documentable_id: od.id,
+                             documentable_type: 'OperatorDocument',
+                             operator_document_annex_id: random_operator_document_annex.id
+      end
       random_operator_document_annex.user ||=
         FactoryBot.create :admin
     end

--- a/spec/factories/operator_document_annexes.rb
+++ b/spec/factories/operator_document_annexes.rb
@@ -2,19 +2,20 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                   :integer          not null, primary key
-#  operator_document_id :integer
-#  name                 :string
-#  start_date           :date
-#  expire_date          :date
-#  deleted_at           :date
-#  status               :integer
-#  attachment           :string
-#  uploaded_by          :integer
-#  user_id              :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  public               :boolean          default("true"), not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  start_date        :date
+#  expire_date       :date
+#  deleted_at        :date
+#  status            :integer
+#  attachment        :string
+#  uploaded_by       :integer
+#  user_id           :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  public            :boolean          default("true"), not null
+#  documentable_id   :integer
+#  documentable_type :string
 #
 
 FactoryBot.define do

--- a/spec/factories/operator_document_histories.rb
+++ b/spec/factories/operator_document_histories.rb
@@ -1,0 +1,46 @@
+# == Schema Information
+#
+# Table name: operator_document_histories
+#
+#  id                            :integer          not null, primary key
+#  type                          :string
+#  expire_date                   :date
+#  start_date                    :date
+#  status                        :integer
+#  uploaded_by                   :integer
+#  reason                        :text
+#  note                          :text
+#  response_date                 :datetime
+#  public                        :boolean
+#  source                        :integer
+#  source_info                   :string
+#  fmu_id                        :integer
+#  document_file_id              :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  operator_document_id          :integer
+#  operator_id                   :integer
+#  user_id                       :integer
+#  required_operator_document_id :integer
+#
+
+FactoryBot.define do
+  factory :operator_document_history do
+    user
+    expire_date { Date.tomorrow }
+    start_date { Date.yesterday }
+    document_file { FactoryBot.build :document_file}
+    operator { FactoryBot.build :operator }
+    required_operator_document { FactoryBot.build :required_operator_document}
+
+    factory :operator_document_country_history, class: OperatorDocumentCountryHistory do
+      type { 'OperatorDocumentCountryHistory' }
+    end
+
+    factory :operator_document_fmu_history, class: OperatorDocumentFmuHistory do
+      fmu
+      required_operator_document_fmu
+      type { 'OperatorDocumentFmuHistory' }
+    end
+  end
+end

--- a/spec/factories/operator_documents.rb
+++ b/spec/factories/operator_documents.rb
@@ -13,7 +13,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/factories/operator_documents.rb
+++ b/spec/factories/operator_documents.rb
@@ -12,7 +12,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/factories/operator_documents.rb
+++ b/spec/factories/operator_documents.rb
@@ -29,8 +29,9 @@ FactoryBot.define do
     user
     expire_date { Date.tomorrow }
     start_date { Date.yesterday }
-    current { true }
-    attachment { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files', 'image.png')) }
+    type { 'OperatorDocumentCountry' } # This can be overwritten by the children.
+    document_file { FactoryBot.build :document_file }
+
 
     after(:build) do |random_operator_document|
       country = random_operator_document&.operator&.country ||

--- a/spec/factories/operator_documents.rb
+++ b/spec/factories/operator_documents.rb
@@ -23,6 +23,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 FactoryBot.define do

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -15,6 +15,7 @@
 #  address       :string
 #  website       :string
 #  approved      :boolean          default("true"), not null
+#  email         :string
 #  name          :string
 #  details       :text
 #

--- a/spec/integration/v1/operator_document_histories_spec.rb
+++ b/spec/integration/v1/operator_document_histories_spec.rb
@@ -39,7 +39,7 @@ module V1
       end
       describe 'Invalid date' do
         it 'Fails with a descriptive message' do
-          get("/operator-document-histories?filter[operator-id]=1&filter[date]=#{Date.today}",
+          get("/operator-document-histories?filter[operator-id]=1&filter[date]=wrong-date",
               headers: admin_headers)
           expect(status).to eql(400)
           expect(parsed_error).to eql('Invalid date format. Use: YYYY-MM-DD')

--- a/spec/integration/v1/operator_document_histories_spec.rb
+++ b/spec/integration/v1/operator_document_histories_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+module V1
+  describe 'OperatorDocumentHistory', type: :request do
+    context 'Wrong parameters' do
+      let(:operator_document) { FactoryBot.create :operator_document_country }
+
+      describe 'No filters' do
+        it 'Fails with a descriptive message' do
+          get('/operator-document-histories',
+              headers: admin_headers)
+          expect(status).to eql(400)
+          expect(parsed_error).to eql('Please add the date and operator-id filters')
+        end
+      end
+      describe 'No date' do
+        it 'Fails with a descriptive message' do
+          get("/operator-document-histories?filter[operator-id]=#{operator_document.operator_id}",
+              headers: admin_headers)
+          expect(status).to eql(400)
+          expect(parsed_error).to eql('You must provide a date')
+        end
+      end
+      describe 'No operator-id' do
+        it 'Fails with a descriptive message' do
+          get("/operator-document-histories?filter[date]=#{Date.today.to_s(:db)}",
+              headers: admin_headers)
+          expect(status).to eql(400)
+          expect(parsed_error).to eql('You must provide an operator-id')
+        end
+      end
+      describe 'operator-id is not an integer' do
+        it 'Fails with a descriptive message' do
+          get("/operator-document-histories?filter[operator-id]=aa&filter[date]=#{Date.today.to_s(:db)}",
+              headers: admin_headers)
+          expect(status).to eql(400)
+          expect(parsed_error).to eql('Operator must be an integer')
+        end
+      end
+      describe 'Invalid date' do
+        it 'Fails with a descriptive message' do
+          get("/operator-document-histories?filter[operator-id]=1&filter[date]=#{Date.today}",
+              headers: admin_headers)
+          expect(status).to eql(400)
+          expect(parsed_error).to eql('Invalid date format. Use: YYYY-MM-DD')
+        end
+      end
+
+    end
+    context 'Fetch History of changed document' do
+      describe 'Modify operator document' do
+        before do
+          travel_to Time.local(2020, 10, 5, 0, 0, 0)
+        end
+
+        after do
+          travel_back
+        end
+        let(:time1) { Time.local(2020, 10, 10, 0, 0, 0) }
+        let(:time2) { Time.local(2020, 10, 15, 0, 0, 0) }
+        let(:time3) { Time.local(2020, 10, 20, 0, 0, 0)}
+        it 'Fetches the old state of the operator' do
+          operator_document = FactoryBot.create :operator_document_country
+          attachment = operator_document.document_file.attachment_url
+          travel_to time1
+          operator_document.update(status: 'doc_valid')
+          travel_to time2
+          operator_document.update note: 'new note'
+          travel_to time3
+          operator_document.destroy
+
+          search_time = (time1 + 2.day).to_date.to_s(:db)
+          get("/operator-document-histories?filter[date]=#{search_time}&filter[operator-id]=#{operator_document.operator_id}",
+              headers: admin_headers)
+          expect(status).to eql(200)
+          expect(first_parsed_attributes[:status]).to eql('doc_valid')
+          expect(first_parsed_attributes[:attachment][:url]).to eql(attachment)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -17,8 +17,16 @@ module IntegrationHelper
     parsed_data[:attributes]
   end
 
+  def first_parsed_attributes
+    parsed_data.first[:attributes]
+  end
+
   def parsed_body
     Oj.load(response.body, symbol_keys: true)
+  end
+
+  def parsed_error
+    parsed_body[:error]
   end
 
   def login_user(user)

--- a/spec/models/document_file_spec.rb
+++ b/spec/models/document_file_spec.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: document_files
+#
+#  id         :integer          not null, primary key
+#  attachment :string
+#  file_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe DocumentFile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/fmu_spec.rb
+++ b/spec/models/fmu_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Fmu, type: :model do
     describe '#really_destroy_documents' do
       it 'destroy operator_documents associated with the fmu' do
         another_fmu = create(:fmu)
-        operator_document = create(:operator_document, fmu: another_fmu)
+        operator_document = create(:operator_document_fmu, fmu: another_fmu)
         another_fmu.destroy
 
         expect(OperatorDocument.where(id: operator_document.id).first).to be_nil

--- a/spec/models/observation_report_spec.rb
+++ b/spec/models/observation_report_spec.rb
@@ -24,14 +24,7 @@ RSpec.describe ObservationReport, type: :model do
     describe '#remove_attachment_id_directory' do
       it 'removes all attached documents' do
         observation_report = create(:observation_report)
-        filepath = File.join(
-          'public',
-          'uploads',
-          'observation_report',
-          'attachment',
-          observation_report.id.to_s,
-          "observationreporttitle#{observation_report.id}-2015-09-01.png"
-        )
+        filepath = File.join "public", observation_report.attachment_url
 
         expect(File.exist?(filepath)).to eql true
 

--- a/spec/models/operator_document_annex_spec.rb
+++ b/spec/models/operator_document_annex_spec.rb
@@ -2,19 +2,20 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                   :integer          not null, primary key
-#  operator_document_id :integer
-#  name                 :string
-#  start_date           :date
-#  expire_date          :date
-#  deleted_at           :date
-#  status               :integer
-#  attachment           :string
-#  uploaded_by          :integer
-#  user_id              :integer
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  public               :boolean          default("true"), not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  start_date        :date
+#  expire_date       :date
+#  deleted_at        :date
+#  status            :integer
+#  attachment        :string
+#  uploaded_by       :integer
+#  user_id           :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  public            :boolean          default("true"), not null
+#  documentable_id   :integer
+#  documentable_type :string
 #
 
 require 'rails_helper'

--- a/spec/models/operator_document_annex_spec.rb
+++ b/spec/models/operator_document_annex_spec.rb
@@ -2,20 +2,18 @@
 #
 # Table name: operator_document_annexes
 #
-#  id                :integer          not null, primary key
-#  name              :string
-#  start_date        :date
-#  expire_date       :date
-#  deleted_at        :date
-#  status            :integer
-#  attachment        :string
-#  uploaded_by       :integer
-#  user_id           :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  public            :boolean          default("true"), not null
-#  documentable_id   :integer
-#  documentable_type :string
+#  id          :integer          not null, primary key
+#  name        :string
+#  start_date  :date
+#  expire_date :date
+#  deleted_at  :date
+#  status      :integer
+#  attachment  :string
+#  uploaded_by :integer
+#  user_id     :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  public      :boolean          default("true"), not null
 #
 
 require 'rails_helper'

--- a/spec/models/operator_document_country_spec.rb
+++ b/spec/models/operator_document_country_spec.rb
@@ -13,7 +13,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_country_spec.rb
+++ b/spec/models/operator_document_country_spec.rb
@@ -12,7 +12,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_country_spec.rb
+++ b/spec/models/operator_document_country_spec.rb
@@ -23,6 +23,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 require 'rails_helper'

--- a/spec/models/operator_document_country_spec.rb
+++ b/spec/models/operator_document_country_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OperatorDocumentCountry, type: :model do
             create(:required_operator_document_country, contract_signature: true, country: country)
           operator_document = create(:operator_document_country,
                  required_operator_document: required_operator_document,
-                 operator: operator, current: true)
+                 operator: operator)
 
           operator_document.status = :doc_valid
           operator_document.save

--- a/spec/models/operator_document_fmu_spec.rb
+++ b/spec/models/operator_document_fmu_spec.rb
@@ -13,7 +13,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_fmu_spec.rb
+++ b/spec/models/operator_document_fmu_spec.rb
@@ -12,7 +12,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_fmu_spec.rb
+++ b/spec/models/operator_document_fmu_spec.rb
@@ -23,6 +23,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 require 'rails_helper'

--- a/spec/models/operator_document_history_spec.rb
+++ b/spec/models/operator_document_history_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OperatorDocumentHistory, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/operator_document_history_spec.rb
+++ b/spec/models/operator_document_history_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: operator_document_histories
+#
+#  id                            :integer          not null, primary key
+#  type                          :string
+#  expire_date                   :date
+#  start_date                    :date
+#  status                        :integer
+#  uploaded_by                   :integer
+#  reason                        :text
+#  note                          :text
+#  response_date                 :datetime
+#  public                        :boolean
+#  source                        :integer
+#  source_info                   :string
+#  fmu_id                        :integer
+#  document_file_id              :integer
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  operator_document_id          :integer
+#  operator_id                   :integer
+#  user_id                       :integer
+#  required_operator_document_id :integer
+#
 require 'rails_helper'
 
 RSpec.describe OperatorDocumentHistory, type: :model do

--- a/spec/models/operator_document_history_spec.rb
+++ b/spec/models/operator_document_history_spec.rb
@@ -26,5 +26,54 @@
 require 'rails_helper'
 
 RSpec.describe OperatorDocumentHistory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe 'Existence' do
+    let (:od) { FactoryBot.create(:operator_document_country) }
+    context 'Creating an OperatorDocument' do
+      it 'Adds an OperatorDocumentHistory' do
+        odh = OperatorDocumentHistory.find_by(operator_document_id: od.id)
+        expect(odh).not_to be_nil
+        expect(odh.type).to eql(od.type  + 'History')
+        expect(odh.expire_date).to eql(od.expire_date)
+        expect(odh.start_date).to eql(od.start_date)
+        expect(odh.uploaded_by).to eql(od.uploaded_by)
+        expect(odh.reason).to eql(od.reason)
+        expect(odh.note).to eql(od.note)
+        expect(odh.response_date).to eql(od.response_date)
+        expect(odh.public).to eql(od.public)
+        expect(odh.source).to eql(od.source)
+        expect(odh.source_info).to eql(od.source_info)
+        expect(odh.fmu_id).to eql(od.fmu_id)
+        expect(odh.document_file_id).to eql(od.document_file_id)
+        expect(odh.created_at.to_i).to eql(od.created_at.to_i)
+        expect(odh.updated_at.to_i).to eql(od.updated_at.to_i)
+        expect(odh.operator_id).to eql(od.operator_id)
+        expect(odh.user_id).to eql(od.user_id)
+        expect(odh.required_operator_document_id).to eql(od.required_operator_document_id)
+      end
+    end
+    context 'Updating an OperatorDocument' do
+      it 'Adds a new version of the OperatorDocumentHistory' do
+        od.update(note: 'new note')
+        od.reload
+        odhs = OperatorDocumentHistory.where(operator_document_id: od.id).order({updated_at: :desc})
+        expect(odhs.count).to eql(2)
+        expect(odhs.first.note).to eql('new note')
+        expect(odhs.first.updated_at.to_i).to eql(od.updated_at.to_i)
+        expect(odhs.last.note).to be_nil
+      end
+    end
+    context 'Deletes an OperatorDocument' do
+      it 'Adds a new version of OperatorDocumentHistory and keeps the file' do
+        document_file = od.document_file
+        od.destroy
+        od.reload
+        odhs = OperatorDocumentHistory.where(operator_document_id: od.id).order({updated_at: :desc})
+        expect(odhs.count).to eql(2)
+        expect(odhs.first.status).to eql('doc_not_provided')
+        expect(odhs.last.document_file_id).to eql(document_file.id)
+        expect(document_file.attachment).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/operator_document_spec.rb
+++ b/spec/models/operator_document_spec.rb
@@ -13,7 +13,6 @@
 #  status                        :integer
 #  operator_id                   :integer
 #  attachment                    :string
-#  current                       :boolean
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_spec.rb
+++ b/spec/models/operator_document_spec.rb
@@ -12,7 +12,6 @@
 #  updated_at                    :datetime         not null
 #  status                        :integer
 #  operator_id                   :integer
-#  attachment                    :string
 #  deleted_at                    :datetime
 #  uploaded_by                   :integer
 #  user_id                       :integer

--- a/spec/models/operator_document_spec.rb
+++ b/spec/models/operator_document_spec.rb
@@ -27,7 +27,7 @@
 require 'rails_helper'
 
 RSpec.describe OperatorDocument, type: :model do
-  subject(:operator_document) { FactoryBot.build(:operator_document) }
+  subject(:operator_document) { FactoryBot.build(:operator_document_country) }
 
   it 'is valid with valid attributes' do
     expect(operator_document).to be_valid
@@ -36,12 +36,12 @@ RSpec.describe OperatorDocument, type: :model do
   describe 'Validations' do
     describe '#start_date' do
       context 'has an attachment' do
-        before { allow(subject).to receive(:attachment?).and_return(true) }
+        before { allow(subject).to receive(:document_file_id?).and_return(true) }
         it { is_expected.to validate_presence_of(:start_date) }
       end
 
       context 'has not an attachment' do
-        before { allow(subject).to receive(:attachment?).and_return(false) }
+        before { allow(subject).to receive(:document_file_id?).and_return(false) }
         it { is_expected.not_to validate_presence_of(:start_date) }
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe OperatorDocument, type: :model do
     describe '#set_expire_date' do
       context 'when there is not expire_date' do
         it 'set expire_date with the start_date plus the valid_period days' do
-          operator_document = build(:operator_document, expire_date: nil)
+          operator_document = build(:operator_document_country, expire_date: nil)
           operator_document.valid?
 
           expect(operator_document.expire_date).to eql(
@@ -63,7 +63,7 @@ RSpec.describe OperatorDocument, type: :model do
     describe '#reason_or_attachment' do
       context 'when there is attachment and reason' do
         it 'add an error on reason' do
-          operator_document = build(:operator_document, reason: 'aaa')
+          operator_document = build(:operator_document_country, reason: 'aaa')
 
           expect(operator_document.valid?).to eql false
           expect(operator_document.errors[:reason]).to eql(
@@ -93,74 +93,27 @@ RSpec.describe OperatorDocument, type: :model do
     describe '#update_current' do
       context 'when there is not operator or he/she is marked for destruction' do
         before do
-          create(:operator_document,
+          create(:operator_document_country,
                  operator: @operator,
                  required_operator_document: @required_operator_document,
-                 fmu: @fmu,
-                 current: true)
+                 fmu: @fmu)
 
           @operator_document = build(
-            :operator_document,
+            :operator_document_country,
             operator: @operator,
             required_operator_document: @required_operator_document,
             fmu: @fmu)
-        end
-
-        context 'when operator_document is the current one' do
-          it 'update related operator_document with current false' do
-            @operator_document.save
-
-            expect(@operator_document.current).to eql true
-            OperatorDocument.where.not(id: @operator_document.id).each do |operator_document|
-              expect(operator_document.current).to eql false
-            end
-          end
         end
       end
     end
 
     describe '#set_status' do
-      context 'when attachment or reason are present' do
-        it 'update status as doc_pending' do
-          operator_document = create(:operator_document)
-
-          expect(operator_document.status).to eql 'doc_pending'
-        end
-      end
-
       context 'when attachment or reason are not present' do
         it 'update status as doc_not_provided' do
-          operator_document = create(:operator_document, attachment: nil, reason: nil)
+          operator_document = create(:operator_document_country, reason: nil, document_file: nil)
 
           expect(operator_document.status).to eql 'doc_not_provided'
         end
-      end
-    end
-
-    describe '#delete_previous_pending_document' do
-      it 'deletes previous pending operator_documents' do
-        another_operator = create(:operator, country: @country, fa_id: 'fa_id')
-        create(
-          :operator_document,
-          operator: another_operator,
-          fmu: @fmu,
-          required_operator_document: @required_operator_document)
-
-        create(
-          :operator_document,
-          operator: @operator,
-          fmu: @fmu,
-          required_operator_document: @required_operator_document)
-
-        expect(OperatorDocument.all.size).to eql 2
-
-        create(
-          :operator_document,
-          operator: @operator,
-          fmu: @fmu,
-          required_operator_document: @required_operator_document)
-
-        expect(OperatorDocument.all.size).to eql 2
       end
     end
 
@@ -170,18 +123,17 @@ RSpec.describe OperatorDocument, type: :model do
         pending_status = OperatorDocument.statuses[:doc_pending]
         common_data = {
           operator_id: @operator.id,
-          current: true,
           required_operator_document_id: @required_operator_document.id,
           public: true
         }
 
         # Generate one valid operator document and two pending operator documents of each type
-        valid_op_doc = create(:operator_document, **common_data)
+        valid_op_doc = create(:operator_document_country, **common_data)
         valid_op_doc.reload
         valid_op_doc.update_attributes(status: valid_status)
         @operator.reload
 
-        pending_op_docs = create_list(:operator_document, 2, **common_data)
+        pending_op_docs = create_list(:operator_document_country, 2, **common_data)
         pending_op_docs.each do |pending_op_doc|
           pending_op_doc.update_attributes(status: pending_status)
           @operator.reload
@@ -209,10 +161,9 @@ RSpec.describe OperatorDocument, type: :model do
               'for destruction, not current operator document and not required operator document' do
         it 'creates a new operator document' do
           operator_document = create(
-            :operator_document,
+            :operator_document_country,
             operator: @operator,
-            required_operator_document: @required_operator_document,
-            current: true)
+            required_operator_document: @required_operator_document)
 
           expect(OperatorDocument.count).to eql 1
 
@@ -227,7 +178,7 @@ RSpec.describe OperatorDocument, type: :model do
   describe 'Instance methods' do
     describe '#expire_document' do
       it 'update status as doc_expired' do
-        operator_document = create(:operator_document)
+        operator_document = create(:operator_document_country)
 
         expect(operator_document.status).not_to eql 'doc_expired'
 
@@ -244,7 +195,7 @@ RSpec.describe OperatorDocument, type: :model do
         required_operator_document =
           create(:required_operator_document, contract_signature: false)
         create(
-          :operator_document,
+          :operator_document_country,
           required_operator_document: required_operator_document,
           status: OperatorDocument.statuses[:doc_valid],
           expire_date: Date.yesterday)

--- a/spec/models/operator_document_spec.rb
+++ b/spec/models/operator_document_spec.rb
@@ -23,6 +23,7 @@
 #  public                        :boolean          default("true"), not null
 #  source                        :integer          default("1")
 #  source_info                   :string
+#  document_file_id              :integer
 #
 
 require 'rails_helper'

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -93,12 +93,10 @@ RSpec.describe Operator, type: :model do
           expect(@other_operator.operator_document_countries.size).to eql 1
           operator_document_country = @other_operator.operator_document_countries.first
           expect(operator_document_country.status).to eql 'doc_not_provided'
-          expect(operator_document_country.current).to eql true
 
           expect(@other_operator.operator_document_fmus.size).to eql 1
           operator_document_fmu = @other_operator.operator_document_fmus.first
           expect(operator_document_fmu.status).to eql 'doc_not_provided'
-          expect(operator_document_fmu.current).to eql true
         end
       end
     end
@@ -106,7 +104,7 @@ RSpec.describe Operator, type: :model do
     describe '#really_destroy_documents' do
       it 'destroy operator_documents associated with the operator' do
         another_operator = create(:operator)
-        operator_document = create(:operator_document, operator: another_operator)
+        operator_document = create(:operator_document_country, operator: another_operator)
         another_operator.send(:really_destroy_documents)
 
         expect(OperatorDocument.where(id: operator_document.id).first).to be_nil
@@ -120,13 +118,12 @@ RSpec.describe Operator, type: :model do
       pending_status = OperatorDocument.statuses[:doc_pending]
       common_data = {
         operator_id: @operator.id,
-        current: true,
         required_operator_document_id: @required_operator_document.id,
         public: true
       }
 
       # Generate one valid operator document and two pending operator documents of each type
-      %i[operator_document operator_document_fmu operator_document_country].each do |op_doc_type|
+      %i[operator_document_country operator_document_fmu operator_document_country].each do |op_doc_type|
         [false, true].each do |public|
           common_data[:public] = public
           common_data[:required_operator_document_id] =
@@ -185,7 +182,7 @@ RSpec.describe Operator, type: :model do
             ScoreOperatorDocument.recalculate! @operator
 
             expect(@operator.score_operator_document.all).to eql(6.0 / @operator_documents_required)
-            expect(@operator.score_operator_document.country).to eql(2.0 / @operator_document_countries_required)
+            expect(@operator.score_operator_document.country).to eql(4.0 / @operator_document_countries_required)
             expect(@operator.score_operator_document.fmu).to eql(2.0 / @operator_document_fmus_required)
           end
         end
@@ -197,7 +194,7 @@ RSpec.describe Operator, type: :model do
             ScoreOperatorDocument.recalculate! @operator
 
             expect(@operator.score_operator_document.all).to eql(3.0 / @operator_documents_required)
-            expect(@operator.score_operator_document.country).to eql(1.0 / @operator_document_countries_required)
+            expect(@operator.score_operator_document.country).to eql(2.0 / @operator_document_countries_required)
             expect(@operator.score_operator_document.fmu).to eql(1.0 / @operator_document_fmus_required)
           end
         end
@@ -260,12 +257,10 @@ RSpec.describe Operator, type: :model do
           expect(@other_operator.operator_document_countries.size).to eql 1
           operator_document_country = @other_operator.operator_document_countries.first
           expect(operator_document_country.status).to eql 'doc_not_provided'
-          expect(operator_document_country.current).to eql true
 
           expect(@other_operator.operator_document_fmus.size).to eql 1
           operator_document_fmu = @other_operator.operator_document_fmus.first
           expect(operator_document_fmu.status).to eql 'doc_not_provided'
-          expect(operator_document_fmu.current).to eql true
         end
       end
     end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -15,6 +15,7 @@
 #  address       :string
 #  website       :string
 #  approved      :boolean          default("true"), not null
+#  email         :string
 #  name          :string
 #  details       :text
 #

--- a/spec/services/mail_service_spec.rb
+++ b/spec/services/mail_service_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe MailService do
   context '#notify_operator_expired_document' do
     let(:country) { FactoryBot.create(:country)}
     let(:operator) { FactoryBot.create(:operator, country_id: country.id, email: 'test@mail.com')}
-    let(:rod1) { FactoryBot.create(:required_operator_document, country_id: country.id)}
-    let(:rod2) { FactoryBot.create(:required_operator_document, country_id: country.id)}
-    let(:document1) { FactoryBot.create(:operator_document, required_operator_document_id: rod1.id,
+    let(:rod1) { FactoryBot.create(:required_operator_document_country, country_id: country.id)}
+    let(:rod2) { FactoryBot.create(:required_operator_document_country, country_id: country.id)}
+    let(:document1) { FactoryBot.create(:operator_document_country, required_operator_document_id: rod1.id,
                                         operator_id: operator, expire_date: Date.today)}
-    let(:document2) { FactoryBot.create(:operator_document, required_operator_document_id: rod2.id,
+    let(:document2) { FactoryBot.create(:operator_document_country, required_operator_document_id: rod2.id,
                                         operator_id: operator, expire_date: Date.today)}
 
     context 'Has documents expiring today' do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
This PR restructures the Operator Documents in a way that it allows for fetching the status of each document in a specific point in time.
In order to achieve this there were some major changes:
- Changed the OperatorDocument attachment to be an independent model called DocumentFile
- Created a OperatorDocumentHistory
- Created a model called AnnexDocument to serve as the many-to-many associative model.
- Added an endpoint to OperatorDocumentHistory that takes the operator-id and data as parameters and displays the data as it was before.
