### PR TITLE
Improved filter tree performance by removing N+1 and unnecessary select fields

### DIFF
--- a/app/controllers/v1/observation_filters_controller.rb
+++ b/app/controllers/v1/observation_filters_controller.rb
@@ -267,9 +267,9 @@ module V1
     end
 
     def operator_ids
-      Operator.active.with_translations.includes(:fmus).map do |x|
-        { id: x.id, name: x.name, fmus: x.fmus.pluck(:id) }
-      end.sort_by { |x| x[:name] }
+      Operator.active_with_fmus_array.map do |x|
+        {id: x[0], name: x[1], fmus: x[2]}
+      end
     end
 
     def subcategory_ids
@@ -285,7 +285,8 @@ module V1
     end
 
     def fmu_ids
-      Fmu.all.with_translations.map{ |x| { id: x.id, name: x.name } }.sort_by { |x| x[:name] }
+      name_column = Arel.sql("fmu_translations.name")
+      Fmu.all.with_translations.order('fmu_translations.name asc').pluck(:id, name_column).map{ |x| {id: x[0], name: x[1] }}
     end
 
     def observer_ids

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -270,6 +270,12 @@ class Operator < ApplicationRecord
     end
   end
 
+  def self.active_with_fmus_array
+    name_column = Arel.sql('operator_translations.name')
+    Operator.active.with_translations.includes(:fmus).group(:id, name_column).order(name_column)
+        .pluck(:id, name_column, 'array_agg(fmus.id) fmu_ids')
+  end
+
   private
 
   # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
This is a hotfix to solve some slow queries that are wrecking the site's performance.