### PR TITLE
Feature/responsible observer

### DIFF
--- a/app/admin/observer.rb
+++ b/app/admin/observer.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register Observer, as: 'Monitor' do
 
   permit_params :observer_type, :is_active, :logo, :address, :information_name, :information_email, :public_info,
                 :information_phone, :data_name, :data_email, :data_phone, :organization_type, :delete_logo,
-                translations_attributes: [:id, :locale, :name, :_destroy], country_ids: []
+                :responsible_user_id, translations_attributes: [:id, :locale, :name, :_destroy], country_ids: []
 
   csv do
     column :is_active
@@ -53,6 +53,7 @@ ActiveAdmin.register Observer, as: 'Monitor' do
     column :observer_type, sortable: true
     image_column :logo
     column :name, sortable: 'observer_translations.name'
+    column :responsible_user
     column :created_at
     column :updated_at
     actions
@@ -73,6 +74,7 @@ ActiveAdmin.register Observer, as: 'Monitor' do
       row :public_info
       row :observer_type
       row :organization_type
+      row :responsible_user
       # TODO: Reactivate rubocop and fix this
       # rubocop:disable Rails/OutputSafety
       row :countries do |observer|
@@ -107,6 +109,7 @@ ActiveAdmin.register Observer, as: 'Monitor' do
     end
     f.inputs 'Monitor Details' do
       f.input :is_active
+      f.input :responsible_user, as: :select, collection: User.where(observer_id: f.object.id)
       f.input :countries, collection: Country.with_translations(I18n.locale).order('country_translations.name asc')
       f.input :observer_type, as: :select, collection: %w(Mandated SemiMandated External Government)
       f.input :organization_type, as: :select, collection: ['NGO', 'Academic', 'Research Institute', 'Private Company', 'Other']

--- a/app/models/observer.rb
+++ b/app/models/observer.rb
@@ -100,9 +100,9 @@ class Observer < ApplicationRecord
   private
 
   def valid_responsible_user
-    return if responsible_user_id.blank?
+    return if responsible_user.blank?
     return if responsible_user.observer_id == id
 
-    errors.add(:responsible_user_id, 'The user must be an observer for this organizations')
+    errors.add(:responsible_user, 'The user must be an observer for this organizations')
   end
 end

--- a/app/models/observer.rb
+++ b/app/models/observer.rb
@@ -4,23 +4,24 @@
 #
 # Table name: observers
 #
-#  id                :integer          not null, primary key
-#  observer_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  is_active         :boolean          default("true")
-#  logo              :string
-#  address           :string
-#  information_name  :string
-#  information_email :string
-#  information_phone :string
-#  data_name         :string
-#  data_email        :string
-#  data_phone        :string
-#  organization_type :string
-#  public_info       :boolean          default("false")
-#  name              :string
-#  organization      :string
+#  id                  :integer          not null, primary key
+#  observer_type       :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  is_active           :boolean          default("true")
+#  logo                :string
+#  address             :string
+#  information_name    :string
+#  information_email   :string
+#  information_phone   :string
+#  data_name           :string
+#  data_email          :string
+#  data_phone          :string
+#  organization_type   :string
+#  public_info         :boolean          default("false")
+#  responsible_user_id :integer
+#  name                :string
+#  organization        :string
 #
 
 class Observer < ApplicationRecord
@@ -47,6 +48,7 @@ class Observer < ApplicationRecord
   has_many :observation_reports, through: :observation_report_observers
 
   has_many :users, inverse_of: :observer
+  belongs_to :responsible_user, class_name: 'User', foreign_key: 'responsible_user_id'
 
   EMAIL_VALIDATOR = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
 
@@ -59,6 +61,8 @@ class Observer < ApplicationRecord
 
   validates_format_of :information_email, with: EMAIL_VALIDATOR, if: :information_email?
   validates_format_of :data_email, with: EMAIL_VALIDATOR, if: :data_email?
+
+  validate :valid_responsible_user
 
   scope :by_name_asc, -> {
     includes(:translations).with_translations(I18n.available_locales)
@@ -91,5 +95,14 @@ class Observer < ApplicationRecord
 
   def cache_key
     super + '-' + Globalize.locale.to_s
+  end
+
+  private
+
+  def valid_responsible_user
+    return if responsible_user_id.blank?
+    return if responsible_user.observer_id == id
+
+    errors.add(:responsible_user_id, 'The user must be an observer for this organizations')
   end
 end

--- a/db/migrate/20201209161058_add_responsible_user_to_observer.rb
+++ b/db/migrate/20201209161058_add_responsible_user_to_observer.rb
@@ -1,0 +1,7 @@
+class AddResponsibleUserToObserver < ActiveRecord::Migration[5.0]
+  def change
+
+    add_column :observers, :responsible_user_id, :integer, index: :true
+    add_foreign_key :observers, :users, column: :responsible_user_id, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201209131235) do
+ActiveRecord::Schema.define(version: 20201209161058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -539,10 +539,10 @@ ActiveRecord::Schema.define(version: 20201209131235) do
   end
 
   create_table "observers", force: :cascade do |t|
-    t.string   "observer_type",                     null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.boolean  "is_active",         default: true
+    t.string   "observer_type",                       null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.boolean  "is_active",           default: true
     t.string   "logo"
     t.string   "address"
     t.string   "information_name"
@@ -552,7 +552,8 @@ ActiveRecord::Schema.define(version: 20201209131235) do
     t.string   "data_email"
     t.string   "data_phone"
     t.string   "organization_type"
-    t.boolean  "public_info",       default: false
+    t.boolean  "public_info",         default: false
+    t.integer  "responsible_user_id"
     t.index ["is_active"], name: "index_observers_on_is_active", using: :btree
   end
 
@@ -1044,6 +1045,7 @@ ActiveRecord::Schema.define(version: 20201209131235) do
   add_foreign_key "observations", "operators"
   add_foreign_key "observations", "users"
   add_foreign_key "observations", "users", column: "modified_user_id"
+  add_foreign_key "observers", "users", column: "responsible_user_id", on_delete: :nullify
   add_foreign_key "operator_document_histories", "operator_documents", on_delete: :nullify
   add_foreign_key "operator_document_histories", "operators", on_delete: :cascade
   add_foreign_key "operator_document_histories", "required_operator_documents", on_delete: :cascade

--- a/spec/factories/observers.rb
+++ b/spec/factories/observers.rb
@@ -2,23 +2,24 @@
 #
 # Table name: observers
 #
-#  id                :integer          not null, primary key
-#  observer_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  is_active         :boolean          default("true")
-#  logo              :string
-#  address           :string
-#  information_name  :string
-#  information_email :string
-#  information_phone :string
-#  data_name         :string
-#  data_email        :string
-#  data_phone        :string
-#  organization_type :string
-#  public_info       :boolean          default("false")
-#  name              :string
-#  organization      :string
+#  id                  :integer          not null, primary key
+#  observer_type       :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  is_active           :boolean          default("true")
+#  logo                :string
+#  address             :string
+#  information_name    :string
+#  information_email   :string
+#  information_phone   :string
+#  data_name           :string
+#  data_email          :string
+#  data_phone          :string
+#  organization_type   :string
+#  public_info         :boolean          default("false")
+#  responsible_user_id :integer
+#  name                :string
+#  organization        :string
 #
 
 FactoryBot.define do

--- a/spec/integration/v1/observations_spec.rb
+++ b/spec/integration/v1/observations_spec.rb
@@ -173,7 +173,7 @@ module V1
                   params: jsonapi_params('observations', observation.id, { 'validation-status': 'Needs revision'}),
                   headers: admin_headers)
 
-            expect(parsed_body[:errors].first[:title]).to eq("Invalid validation change for monitor. Can't move from 'Created'' to ''Needs revision''")
+            expect(parsed_body[:errors].first[:title]).to eq("Invalid validation change for monitor. Can't move from 'Created' to 'Needs revision'")
             expect(status).to eq(422)
           end
         end

--- a/spec/models/observer_spec.rb
+++ b/spec/models/observer_spec.rb
@@ -2,23 +2,24 @@
 #
 # Table name: observers
 #
-#  id                :integer          not null, primary key
-#  observer_type     :string           not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  is_active         :boolean          default("true")
-#  logo              :string
-#  address           :string
-#  information_name  :string
-#  information_email :string
-#  information_phone :string
-#  data_name         :string
-#  data_email        :string
-#  data_phone        :string
-#  organization_type :string
-#  public_info       :boolean          default("false")
-#  name              :string
-#  organization      :string
+#  id                  :integer          not null, primary key
+#  observer_type       :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  is_active           :boolean          default("true")
+#  logo                :string
+#  address             :string
+#  information_name    :string
+#  information_email   :string
+#  information_phone   :string
+#  data_name           :string
+#  data_email          :string
+#  data_phone          :string
+#  organization_type   :string
+#  public_info         :boolean          default("false")
+#  responsible_user_id :integer
+#  name                :string
+#  organization        :string
 #
 
 require 'rails_helper'


### PR DESCRIPTION
The responsible user for an observation is now assigned automatically by:

1 - Grabbing the responsible admin of the monitor organization of the user who uploaded the observation.
2 - When not available, selecting a responsible admin of one of the monitor organizations that reported the observation.