### PR TITLE
Rejects OperatorDocumentHistories where optDocuments are orphan

### DIFF
--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -58,7 +58,10 @@ class OperatorDocumentHistory < ApplicationRecord
       where sq.row_number = 1) as operator_document_histories
     SQL
 
+    all_document_histories = from(query)
+    opt = Operator.find(operator_id)
+    rejected = all_document_histories.pluck(:operator_document_id).reject{ |x| opt.operator_documents.pluck(:id).include? x }
 
-    from(query)
+    all_document_histories.where.not(operator_document_id:rejected)
   end
 end


### PR DESCRIPTION
[BUG - urgent : Ranking of producers on their profile page is wrong](https://www.pivotaltracker.com/n/projects/2031625/stories/175915896)
Fixes some inconsistencies with OperatorDocumentHistories without an existing document. 