### PR TITLE
Fix/regenerate operator document files

### DIFF
--- a/app/models/document_file.rb
+++ b/app/models/document_file.rb
@@ -6,7 +6,6 @@
 #
 #  id         :integer          not null, primary key
 #  attachment :string
-#  file_name  :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/document_file.rb
+++ b/app/models/document_file.rb
@@ -14,4 +14,9 @@ class DocumentFile < ApplicationRecord
   mount_base64_uploader :attachment, DocumentFileUploader
 
   has_one :operator_document, inverse_of: :document_file
+  has_one :operator_document_history, inverse_of: :document_file
+
+  def owner
+    @owner ||= operator_document || operator_document_history
+  end
 end

--- a/app/models/operator_document_country_history.rb
+++ b/app/models/operator_document_country_history.rb
@@ -24,6 +24,7 @@
 #  operator_id                   :integer
 #  user_id                       :integer
 #  required_operator_document_id :integer
+#  deleted_at                    :datetime
 #
 class OperatorDocumentCountryHistory < OperatorDocumentHistory
 

--- a/app/models/operator_document_fmu_history.rb
+++ b/app/models/operator_document_fmu_history.rb
@@ -24,6 +24,7 @@
 #  operator_id                   :integer
 #  user_id                       :integer
 #  required_operator_document_id :integer
+#  deleted_at                    :datetime
 #
 class OperatorDocumentFmuHistory < OperatorDocumentHistory
 

--- a/app/models/operator_document_history.rb
+++ b/app/models/operator_document_history.rb
@@ -24,6 +24,7 @@
 #  operator_id                   :integer
 #  user_id                       :integer
 #  required_operator_document_id :integer
+#  deleted_at                    :datetime
 #
 class OperatorDocumentHistory < ApplicationRecord
   acts_as_paranoid

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -24,9 +24,6 @@ module OperatorDocumentable
     end
 
     def attachment
-      # unless @model.attachment.nil?
-      #   return { url: @model&.document_file&.attachment.store_dir.gsub("_file","").gsub(@model.document_file.id.to_s,"") + @model.id.to_s + "/" + @model.attachment } if can_see_document? || document_public?
-      # end
       return @model&.document_file&.attachment if can_see_document? || document_public?
 
       { url: nil }

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -17,6 +17,7 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
 
   def filename
     return super if model.operator_document.nil?
+    return if super.blank?
 
     filename = [
       model.operator_document.operator.name[0...30]&.parameterize,

--- a/db/migrate/20210527135115_drop_attachment_from_operator_documents.rb
+++ b/db/migrate/20210527135115_drop_attachment_from_operator_documents.rb
@@ -1,0 +1,5 @@
+class DropAttachmentFromOperatorDocuments < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :operator_documents, :attachment, :string
+  end
+end

--- a/db/migrate/20210528085923_drop_file_name_from_document_files.rb
+++ b/db/migrate/20210528085923_drop_file_name_from_document_files.rb
@@ -1,0 +1,5 @@
+class DropFileNameFromDocumentFiles < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :document_files, :file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210106151820) do
+ActiveRecord::Schema.define(version: 20210527135115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -623,7 +623,6 @@ ActiveRecord::Schema.define(version: 20210106151820) do
     t.datetime "updated_at",                                   null: false
     t.integer  "status"
     t.integer  "operator_id"
-    t.string   "attachment"
     t.datetime "deleted_at"
     t.integer  "uploaded_by"
     t.integer  "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210527135115) do
+ActiveRecord::Schema.define(version: 20210528085923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,7 +192,6 @@ ActiveRecord::Schema.define(version: 20210527135115) do
 
   create_table "document_files", force: :cascade do |t|
     t.string   "attachment"
-    t.string   "file_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/tasks/fix.rake
+++ b/lib/tasks/fix.rake
@@ -29,7 +29,13 @@ namespace :fix do
       start_name = operator.name[0...30]&.parameterize
       next if df.attachment.identifier.start_with?(start_name)
 
-      puts "WRONG NAME #{df.attachment.identifier}"
+      new_name = [
+        operator.name[0...30]&.parameterize,
+        df.owner.required_operator_document.name[0...100]&.parameterize,
+        df.created_at.strftime('%Y-%m-%d')
+      ].compact.join('-') + File.extname(filename)
+
+      puts "WRONG NAME #{df.attachment.identifier} will be changed to #{new_name}"
       count_wrong_name += 1
     end
 

--- a/lib/tasks/fix.rake
+++ b/lib/tasks/fix.rake
@@ -1,0 +1,41 @@
+require 'csv'
+
+namespace :fix do
+  desc 'Fixing operator document generated names'
+  task operator_documents_names: :environment do
+    count_no_relation = 0
+    count_no_operator = 0
+    count_wrong_name = 0
+
+    DocumentFile.find_each do |df|
+      if df.owner.nil?
+        puts "NO relation for document #{df.id}"
+        count_no_relation +=1
+        next
+      end
+
+      operator = df.owner.operator
+      if operator.nil?
+        puts "NO operator document for #{df.id}"
+        count_no_operator += 1
+        next
+      end
+
+      filename = df.attachment.identifier
+      filename_no_ext = File.basename(filename, File.extname(filename))
+
+      next if filename.match(/\d{4}-\d{2}-\d{2}/) # have date in filename then I would say it is ok
+
+      start_name = operator.name[0...30]&.parameterize
+      next if df.attachment.identifier.start_with?(start_name)
+
+      puts "WRONG NAME #{df.attachment.identifier}"
+      count_wrong_name += 1
+    end
+
+    puts "TOTAL COUNT #{DocumentFile.all.count}"
+    puts "NO OPERATORS #{count_no_operator}"
+    puts "NO RELATION #{count_no_relation}"
+    puts "WRONG NAME #{count_wrong_name}"
+  end
+end

--- a/lib/tasks/operator_document_history.rake
+++ b/lib/tasks/operator_document_history.rake
@@ -58,40 +58,4 @@ namespace :operator_documents_histories do
         end
     end
   end
-
-  desc 'Checks for OperatorDocumentHistories with wrong attachment urls and fixs it'
-  task fix_urls: :environment do
-    broken_urls = []
-    OperatorDocumentHistory.unscoped.each do |odh|
-      if odh.document_file.present?
-       if odh.document_file.attachment.url.split('.').count == 1
-          broken_urls.push(odh.id)
-        end
-      end
-    end
-    puts 'broken_urls.count'
-    puts broken_urls.count
-
-    broken_urls.each do |odh_id|
-      odh = OperatorDocumentHistory.unscoped.find(odh_id)
-      if odh.operator_document.attachment&.split('.').count == 2
-        puts 'fixing ' + odh.id.to_s
-        new_file_name = odh.document_file.file_name + '.' + odh.operator_document.attachment&.split('.')&.last
-        odh.document_file.file_name = new_file_name
-        odh.document_file.attachment = new_file_name
-        odh.document_file.save!
-      end
-    end
-  
-    after_broken_urls = []
-    OperatorDocumentHistory.unscoped.each do |odh|
-      if odh.document_file.present?
-        if odh.document_file.attachment.url.split('.').count == 1
-          after_broken_urls.push(odh.id)
-        end
-      end
-    end
-    puts 'after_broken_urls.count'
-    puts after_broken_urls.count
-  end
 end

--- a/spec/factories/document_file.rb
+++ b/spec/factories/document_file.rb
@@ -12,7 +12,6 @@
 #
 FactoryBot.define do
   factory :document_file do
-    file_name { 'image'}
     attachment { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'files', 'image.png')) }
   end
 end

--- a/spec/factories/operator_document_histories.rb
+++ b/spec/factories/operator_document_histories.rb
@@ -22,6 +22,7 @@
 #  operator_id                   :integer
 #  user_id                       :integer
 #  required_operator_document_id :integer
+#  deleted_at                    :datetime
 #
 
 FactoryBot.define do

--- a/spec/models/document_file_spec.rb
+++ b/spec/models/document_file_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id         :integer          not null, primary key
 #  attachment :string
-#  file_name  :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/models/operator_document_history_spec.rb
+++ b/spec/models/operator_document_history_spec.rb
@@ -22,6 +22,7 @@
 #  operator_id                   :integer
 #  user_id                       :integer
 #  required_operator_document_id :integer
+#  deleted_at                    :datetime
 #
 require 'rails_helper'
 


### PR DESCRIPTION
In this PR:
- main objective is the one off rake task to fix bad names of attachments which were created over the last couple weeks. Script by default run in dry run mode, meaning nothing will be updated, just will return a bunch of useful info about the state of attachments. To run script to do the thing append env variable `FOR_REAL=true`
- removing old `attachment` column from `OperatorDocument` as attachments were migrated to separate `DocumentFile` model.
- removing redundant `file_name` column from `DocumentFile`, as the attachment column is the same.