### PR TITLE
Fix/score operator document unique constraint

### DIFF
--- a/app/models/score_operator_document.rb
+++ b/app/models/score_operator_document.rb
@@ -22,6 +22,7 @@ class ScoreOperatorDocument < ApplicationRecord
 
   belongs_to :operator, touch: true
   validates_presence_of :date
+  validates_uniqueness_of :current, scope: :operator_id, if: :current?
 
   scope :current, -> { where(current: true) }
 

--- a/db/migrate/20210607152721_add_current_unique_index_to_score_operator_documents.rb
+++ b/db/migrate/20210607152721_add_current_unique_index_to_score_operator_documents.rb
@@ -1,0 +1,5 @@
+class AddCurrentUniqueIndexToScoreOperatorDocuments < ActiveRecord::Migration[5.0]
+  def change
+    add_index :score_operator_documents, [:operator_id, :current], unique: true, where: 'current'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210528085923) do
-
+ActiveRecord::Schema.define(version: 20210607152721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -824,6 +823,7 @@ ActiveRecord::Schema.define(version: 20210528085923) do
     t.datetime "updated_at",                     null: false
     t.index ["current"], name: "index_score_operator_documents_on_current", using: :btree
     t.index ["date"], name: "index_score_operator_documents_on_date", using: :btree
+    t.index ["operator_id", "current"], name: "index_score_operator_documents_on_operator_id_and_current", unique: true, where: "current", using: :btree
     t.index ["operator_id"], name: "index_score_operator_documents_on_operator_id", using: :btree
   end
 


### PR DESCRIPTION
The data on prod should be fixed first otherwise it won't run this migration.