### PR TITLE
versionate section not showing first version

### DIFF
--- a/app/views/layouts/_version.html.erb
+++ b/app/views/layouts/_version.html.erb
@@ -7,7 +7,7 @@
   <b>User</b>: <%= User.find(@versions.last.whodunnit).email rescue '' %>
   <br>
   <% if @versions.length.to_i > 1 %>
-    <% if params[:version].to_i > 1 || !params[:version] %>
+    <% if params[:version].to_i > 0 || !params[:version] %>
       <%= link_to "Previous version", {:version => (params[:version] || @versions.length).to_i - 1}%>
       <br>
     <% end %>


### PR DESCRIPTION
This is a quick one, in version change section it was impossible to go to first "0" version.

 
![image](https://user-images.githubusercontent.com/1286444/122078053-93335680-cdfc-11eb-887d-d975cfe357f8.png)
