### PR TITLE
fix doc history script

### DIFF
--- a/app/admin/operator_document_history.rb
+++ b/app/admin/operator_document_history.rb
@@ -7,6 +7,8 @@ ActiveAdmin.register OperatorDocumentHistory do
   menu false
   config.order_clause
 
+  scope :with_deleted, default: true
+
   sidebar 'Annexes', only: :show do
     attributes_table_for resource do
       ul do
@@ -149,6 +151,8 @@ ActiveAdmin.register OperatorDocumentHistory do
          collection: RequiredOperatorDocument.with_translations.all, as: :select, label: 'Required Operator Document'
   filter :operator, label: 'Operator', as: :select,
                     collection: -> { Operator.with_translations(I18n.locale).order('operator_translations.name') }
+  filter :fmu, label: 'Fmus', as: :select,
+               collection: -> { Fmu.with_translations(I18n.locale).order('fmu_translations.name') }
   filter :status, as: :select, collection: OperatorDocument.statuses
   filter :type, as: :select
   filter :source, as: :select, collection: OperatorDocument.sources

--- a/lib/tasks/fix.rake
+++ b/lib/tasks/fix.rake
@@ -23,7 +23,7 @@ namespace :fix do
         AnnexDocument.where(documentable_type: 'OperatorDocumentHistory').delete_all
 
         OperatorDocument.unscoped.find_each do |od|
-          start_version = od.paper_trail.version_at(date) || od.versions.where('created_at >= ?', date).order(:created_at).first&.reify || od
+          start_version = od.paper_trail.version_at(date) || od.versions.where(event: 'update').where('created_at >= ?', date).order(:created_at).first&.reify || od
 
           next if start_version.blank?
           next if start_version.deleted_at.present?


### PR DESCRIPTION
Fixing script, to only take update paper trail event, reify returns `nil` for created events.