### PR TITLE
Fix/translations operator endpoint

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -16,7 +16,7 @@ class ApiController < ActionController::API
   end
 
   before_action :check_access, :authenticate
-  before_action :set_locale
+  around_action :set_locale
 
   rescue_from ActiveRecord::RecordNotFound,   with: :record_not_found
   rescue_from ActionController::RoutingError, with: :record_not_found
@@ -103,11 +103,12 @@ class ApiController < ActionController::API
     render json: { errors: [{ status: '400', title: 'API Key/Authorization Key mal formed' }] }, status: :bad_request
   end
 
-  def set_locale
-    I18n.locale = if params[:locale].present? && I18n.available_locales.map{ |x| x.to_s }.include?(params[:locale])
-                    params[:locale]
-                  else
-                    I18n.default_locale.to_s
-                  end
+  def set_locale(&action)
+    locale = if params[:locale].present? && I18n.available_locales.map{ |x| x.to_s }.include?(params[:locale])
+               params[:locale]
+             else
+               I18n.default_locale.to_s
+             end
+    I18n.with_locale(locale, &action)
   end
 end

--- a/app/controllers/v1/imports_controller.rb
+++ b/app/controllers/v1/imports_controller.rb
@@ -28,8 +28,8 @@ module V1
       current_user ? { user_id: current_user.id } : { user_id: nil }
     end
 
-    def set_locale
-      I18n.locale = :en
+    def set_locale(&action)
+      I18n.with_locale(:en, &action)
     end
   end
 end

--- a/app/controllers/v1/operators_controller.rb
+++ b/app/controllers/v1/operators_controller.rb
@@ -25,11 +25,5 @@ module V1
       end
       results
     end
-
-    protected
-
-    def set_locale(&action)
-      I18n.with_locale(:en, &action)
-    end
   end
 end

--- a/app/controllers/v1/operators_controller.rb
+++ b/app/controllers/v1/operators_controller.rb
@@ -5,8 +5,6 @@ module V1
     include ErrorSerializer
     include ApiUploads
 
-    before_action :set_locale, only: [:index, :show]
-    after_action  :reset_locale, only: [:index, :show]
     skip_before_action :authenticate, only: [:index, :show, :create]
     load_and_authorize_resource class: 'Operator'
 
@@ -29,13 +27,9 @@ module V1
     end
 
     protected
-    
-    def set_locale
-      I18n.locale = :en
-    end
 
-    def reset_locale
-      I18n.locale = params[:locale] || I18n.default_locale
+    def set_locale(&action)
+      I18n.with_locale(:en, &action)
     end
   end
 end

--- a/app/resources/v1/operator_resource.rb
+++ b/app/resources/v1/operator_resource.rb
@@ -37,6 +37,10 @@ module V1
       @model.is_active = false
     end
 
+    def name
+      I18n.with_locale(:en) { @model.name }
+    end
+
     filter :certification, apply: ->(records, value, _options) {
       values = value.select { |c| %w(fsc pefc olb pafc fsc_cw tlv ls).include? c }
       return records unless values.any?


### PR DESCRIPTION
- fix translations for operator's endpoint to be returned with chosen locale
- return only name always in english
- use around_action instead of before, after as it stays in Rails guides