### PR TITLE
Feat/country required on operator create

### DIFF
--- a/app/admin/operator.rb
+++ b/app/admin/operator.rb
@@ -37,6 +37,9 @@ ActiveAdmin.register Operator, as: 'Producer' do
     link_to 'Delete Producer', admin_producer_path(operator), method: :delete, data: { confirm: confirmation_text }
   end
 
+  action_item only: [:index] do
+    link_to 'New Producer', new_admin_producer_path
+  end
 
   csv do
     column :id

--- a/app/importers/observations_importer.rb
+++ b/app/importers/observations_importer.rb
@@ -35,5 +35,7 @@ class ObservationsImporter < FileDataImport::BaseImporter
 
   belongs_to Operator,
              permitted_attributes: %i[approved operator_type concession is_active logo website address delete_logo],
-             permitted_translations: %i[name details], can: %i[create]
+             permitted_translations: %i[name details],
+             use_shared_belongs_to: %i[country],
+             can: %i[create]
 end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -80,6 +80,7 @@ class Operator < ApplicationRecord
   validates :name, presence: true
   validates :website, url: true, if: lambda { |x| x.website.present? }
   validates :operator_type, inclusion: { in: TYPES }
+  validates :country, presence: true, on: :create
 
   scope :by_name_asc, -> {
     includes(:translations).with_translations(I18n.available_locales)

--- a/lib/file_data_import/belongs_to_association.rb
+++ b/lib/file_data_import/belongs_to_association.rb
@@ -6,7 +6,7 @@ module FileDataImport
 
     attr_accessor(
       :class_name, :permitted_attributes, :permitted_translations,
-      :raw_attributes, :abilities, :errors, :required, :belongs_as
+      :raw_attributes, :abilities, :errors, :required, :belongs_as, :use_shared_belongs_to
     )
 
     def initialize(class_name, raw_attributes, **options)
@@ -17,6 +17,7 @@ module FileDataImport
       @abilities = options[:can]&.map(&:to_sym) || []
       @required = options[:required]
       @belongs_as = options[:as]
+      @use_shared_belongs_to = options[:use_shared_belongs_to] || []
       @errors = {}
     end
 

--- a/lib/file_data_import/record.rb
+++ b/lib/file_data_import/record.rb
@@ -42,6 +42,10 @@ module FileDataImport
       class_name.transaction do
         belongs_to_attributes =
           @belongs_to_associations.each_with_object({}) do |belongs_to_association, attributes|
+            belongs_to_association.use_shared_belongs_to.each do |attribute|
+              use_belongs_to = @belongs_to_associations.find { |b| b.singular_name == attribute }
+              belongs_to_association.record.send("#{attribute}=", use_belongs_to.record) if use_belongs_to.present?
+            end
             belongs_to_association.save
             singular_name = belongs_to_association.singular_name
 

--- a/spec/fixtures/data_import/observations/results.json
+++ b/spec/fixtures/data_import/observations/results.json
@@ -1,1 +1,94 @@
-{"1":{"attributes":{"operator":{"id":1,"approved":true,"operator_type":"Other","concession":null,"is_active":true,"logo":null,"website":null,"address":null,"name":"operator_name","details":null},"record":{"id":null,"observation_type":"operator","publication_date":"2020-12-12T00:00:00.000Z","pv":null,"is_active":false,"location_accuracy":"Estimated location","lat":null,"lng":null,"fmu_id":null,"evidence_type":"Evidence presented in the report","location_information":null,"actions_taken":null,"evidence_on_report":"Page 10","validation_status":"Created","is_physical_place":false,"user_id":null,"details":null,"concern_opinion":null,"litigation_status":null}},"errors":{"record":{"country_id":["can't be blank"]}}},"2":{"attributes":{"country":{"id":1,"iso":"DE","name":"Germany"},"operator":{"id":2,"approved":true,"operator_type":"Other","concession":null,"is_active":true,"logo":null,"website":null,"address":null,"name":"operator_name1","details":null},"record":{"id":1,"observation_type":"operator","publication_date":"2020-12-04T00:00:00.000Z","pv":null,"is_active":false,"location_accuracy":"Estimated location","lat":null,"lng":null,"fmu_id":null,"evidence_type":null,"location_information":null,"actions_taken":null,"evidence_on_report":null,"validation_status":"Created","is_physical_place":false,"user_id":null,"details":null,"concern_opinion":null,"litigation_status":null}},"errors":{}}}
+{
+    "1": {
+        "attributes": {
+            "operator": {
+                "id": null,
+                "approved": true,
+                "operator_type": "Other",
+                "concession": null,
+                "is_active": true,
+                "logo": null,
+                "website": null,
+                "address": null,
+                "name": "operator_name",
+                "details": null
+            },
+            "record": {
+                "id": null,
+                "observation_type": "operator",
+                "publication_date": "2020-12-12T00:00:00.000Z",
+                "pv": null,
+                "is_active": false,
+                "location_accuracy": "Estimated location",
+                "lat": null,
+                "lng": null,
+                "fmu_id": null,
+                "evidence_type": "Evidence presented in the report",
+                "location_information": null,
+                "actions_taken": null,
+                "evidence_on_report": "Page 10",
+                "validation_status": "Created",
+                "is_physical_place": false,
+                "user_id": null,
+                "details": null,
+                "concern_opinion": null,
+                "litigation_status": null
+            }
+        },
+        "errors": {
+            "operator": {
+                "country": [
+                    "can't be blank"
+                ]
+            },
+            "record": {
+                "country_id": [
+                    "can't be blank"
+                ]
+            }
+        }
+    },
+    "2": {
+        "attributes": {
+            "country": {
+                "id": 1,
+                "iso": "DE",
+                "name": "Germany"
+            },
+            "operator": {
+                "id": 1,
+                "approved": true,
+                "operator_type": "Other",
+                "concession": null,
+                "is_active": true,
+                "logo": null,
+                "website": null,
+                "address": null,
+                "name": "operator_name1",
+                "details": null
+            },
+            "record": {
+                "id": 1,
+                "observation_type": "operator",
+                "publication_date": "2020-12-04T00:00:00.000Z",
+                "pv": null,
+                "is_active": false,
+                "location_accuracy": "Estimated location",
+                "lat": null,
+                "lng": null,
+                "fmu_id": null,
+                "evidence_type": null,
+                "location_information": null,
+                "actions_taken": null,
+                "evidence_on_report": null,
+                "validation_status": "Created",
+                "is_physical_place": false,
+                "user_id": null,
+                "details": null,
+                "concern_opinion": null,
+                "litigation_status": null
+            }
+        },
+        "errors": {}
+    }
+}

--- a/spec/integration/v1/operators_spec.rb
+++ b/spec/integration/v1/operators_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 module V1
   describe 'Operator', type: :request do
+    let(:country) { create(:country) }
+
     it_behaves_like "jsonapi-resources", Operator, {
       show: {},
       create: {
         success_roles: %i[admin user webuser],
         failure_roles: [],
-        valid_params: { name: 'Operator one', 'operator-type': 'Other' },
-        invalid_params: { name: '', 'operator-type': 'Other',  },
-        error_attributes: [422, 100, { name: ["can't be blank"] }]
+        valid_params: -> { { name: 'Operator one', 'operator-type': 'Other', relationships: { country: country.id } } },
+        invalid_params: { name: '', 'operator-type': 'Other' },
+        error_attributes: [422, 100, { name: ["can't be blank"], relationships_country: ["can't be blank"] }]
       },
       edit: {
         success_roles: %i[admin],


### PR DESCRIPTION
- Making country required when creating producer
- Bring back "New Producer" button on index page
- Change observations importer to use the same country for creating operators

PT story: https://www.pivotaltracker.com/story/show/178411143