### PR TITLE
Fix/use report publication date as visit date

### DIFF
--- a/app/models/score_operator_observation.rb
+++ b/app/models/score_operator_observation.rb
@@ -57,7 +57,11 @@ class ScoreOperatorObservation < ApplicationRecord
   # We consider "visit" as a day with observations, regardless of the number of observations on the same day
   # So if there are 3 observations for the 1st of January and 10 for the 2nd, there were 2 visits
   def count_visits
-    visits_query = observations.select('date(publication_date)').group('date(publication_date)').count
+    visits_query = observations
+      .joins(:observation_report)
+      .select('date(observation_reports.publication_date)')
+      .group('date(observation_reports.publication_date)')
+      .count
     self.visits = visits_query.keys.count
   end
 

--- a/spec/factories/observations.rb
+++ b/spec/factories/observations.rb
@@ -70,6 +70,7 @@ FactoryBot.define do
   factory :observation, class: 'Observation' do
     country
     subcategory
+    observation_report
     user { build(:admin) }
     severity { build(:severity, subcategory: subcategory) }
     operator { create(:operator, country: country) }

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -226,11 +226,48 @@ RSpec.describe Operator, type: :model do
       end
 
       context 'when there are visits' do
-        it 'update observations per visits and calculate the score' do
-          ScoreOperatorObservation.recalculate! @operator
+        context 'all on the same day' do
+          it 'update observations per visits and calculate the score' do
+            ScoreOperatorObservation.recalculate! @operator
 
-          expect(@operator.score_operator_observation.obs_per_visit).to eql(4.0)
-          expect(@operator.score_operator_observation.score).to eql((4.0 + 2 + 2 + 1) / 9.0)
+            expect(@operator.score_operator_observation.obs_per_visit).to eql(4.0)
+            expect(@operator.score_operator_observation.score).to eql((4.0 + 2 + 2 + 1) / 9.0)
+          end
+        end
+
+        context 'on different days' do
+          before :each do
+            severity = create(:severity, level: 1)
+            # 4 observations already added in before :all for this operator on the same day
+            # adding 2 more on different days, so there will be 3 visits
+            create(
+              :observation,
+              severity: severity,
+              operator: @operator,
+              country: @country,
+              publication_date: 10.days.ago,
+              validation_status: 'Published (no comments)'
+            )
+            create(
+              :observation,
+              severity: severity,
+              operator: @operator,
+              country: @country,
+              publication_date: 3.days.ago,
+              validation_status: 'Published (no comments)'
+            )
+          end
+
+          it 'update observations per visits and calculate the score' do
+            ScoreOperatorObservation.recalculate! @operator
+
+            visits = 3
+
+            expect(@operator.score_operator_observation.obs_per_visit).to eql(6.0 / visits)
+            expect(@operator.score_operator_observation.score).to eql(
+              ((4.0 * 1) / visits + (2.0 * 1) / visits + (2.0 * 1) / visits + (1.0 * 3) / visits) / 9.0
+            )
+          end
         end
       end
     end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -246,15 +246,16 @@ RSpec.describe Operator, type: :model do
               operator: @operator,
               country: @country,
               publication_date: 10.days.ago,
-              validation_status: 'Published (no comments)'
+              validation_status: 'Published (no comments)',
+              observation_report: build(:observation_report, publication_date: 10.days.ago)
             )
             create(
               :observation,
               severity: severity,
               operator: @operator,
               country: @country,
-              publication_date: 3.days.ago,
-              validation_status: 'Published (no comments)'
+              validation_status: 'Published (no comments)',
+              observation_report: build(:observation_report, publication_date: 3.days.ago)
             )
           end
 


### PR DESCRIPTION
Observation visits are counted now by grouping by observation report publication date and not observation publication date. That will change ratios for some operators, that's why manually invoking `observations:recalculate_scores` task is needed after merging this.