### PR TITLE
Fix/duplicated translations

### DIFF
--- a/lib/tasks/fix_one_time.rake
+++ b/lib/tasks/fix_one_time.rake
@@ -2,6 +2,9 @@ namespace :fix_one_time do
   desc 'Fix translation duplications 08.2021'
   task translation_duplicates: :environment do
     for_real = ENV['FOR_REAL'] == 'true'
+
+    puts "RUNNING FOR REAL" if for_real
+    puts "DRY RUN" unless for_real
     # this is one time script to fix translation duplications
     # First time I ran the scripts that removed only duplicates that had same values
     # using that kind of script

--- a/lib/tasks/fix_one_time.rake
+++ b/lib/tasks/fix_one_time.rake
@@ -1,4 +1,58 @@
 namespace :fix_one_time do
+  desc 'Fix translation duplications 08.2021'
+  task translation_duplicates: :environment do
+    for_real = ENV['FOR_REAL'] == 'true'
+    # this is one time script to fix translation duplications
+    # First time I ran the scripts that removed only duplicates that had same values
+    # using that kind of script
+
+    # delete from operator_translations a
+    #   using operator_translations b
+    # where a.updated_at < b.updated_at
+    # and a.operator_id = b.operator_id
+    # and a.locale = b.locale
+    # and coalesce(a.name, '') = coalesce(b.name, '')
+    # and coalesce(a.details, '') = coalesce(b.details, '')
+
+    # after that this list of potentially problematic entities left
+    # {"fmu_id"=>46}
+    # {"fmu_id"=>47}
+    # {"fmu_id"=>49}
+    # {"fmu_id"=>92}
+    # {"observer_id"=>1}
+    # {"observer_id"=>8}
+    # {"operator_id"=>179}
+    # {"operator_id"=>197}
+    # {"operator_id"=>10589}
+    # {"operator_id"=>10604}
+    # {"operator_id"=>10615}
+    # {"operator_id"=>100090}
+    # {"operator_id"=>100091}
+    # {"operator_id"=>100115}
+    # {"operator_id"=>100151}
+    # {"operator_id"=>120128}
+    # {"operator_id"=>120133}
+    # easier to keep the last updated_at translation value and remove the rest, then
+    # check all problematic entities manually in active admin to see if everything is fine
+
+    ActiveRecord::Base.transaction do
+      # I care only about those here, use other rake task to find duplicates
+      %w[operator fmu observer observation country].each do |model|
+        remove_query = <<~SQL
+          delete from #{model}_translations a
+            using #{model}_translations b
+          where a.updated_at < b.updated_at
+            and a.#{model}_id = b.#{model}_id
+            and a.locale = b.locale
+        SQL
+
+        puts "Removing #{model} translations duplicates: #{ActiveRecord::Base.connection.delete(remove_query)}"
+      end
+
+      raise ActiveRecord::Rollback unless for_real
+    end
+  end
+
   desc 'Remove couple not provided docs'
   task remove_mismatched_docs: :environment do
     for_real = ENV['FOR_REAL'] == 'true'


### PR DESCRIPTION
- task to find translation duplicates
- task to remove translation duplicates, keeping the last updated_at record for each entity_id and locale (the list of problematic entities is in the comments in that task, those entities had different values, I will kept the last one, but better to manually look at all of them after cleaning up database)