### PR TITLE
add validated enum attributes for better API errors

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -62,6 +62,8 @@ class Observation < ApplicationRecord
   enum location_accuracy: { "Estimated location" => 0, "GPS coordinates extracted from photo" => 1,
                             "Accurate GPS coordinates" => 2 }
 
+  validate_enum_attributes :observation_type, :evidence_type, :location_accuracy
+
   STATUS_TRANSITIONS={
       monitor: {
           nil => ['Created', 'Ready for QC'],

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -79,7 +79,7 @@ class Operator < ApplicationRecord
 
   validates :name, presence: true
   validates :website, url: true, if: lambda { |x| x.website.present? }
-  validates :operator_type, inclusion: { in: TYPES }
+  validates :operator_type, inclusion: { in: TYPES, message: "can't be %{value}. Valid values are: #{TYPES.join(', ')} " }
   validates :country, presence: true, on: :create
 
   scope :by_name_asc, -> {

--- a/config/initializers/enum_attributes_validation.rb
+++ b/config/initializers/enum_attributes_validation.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# copy paste from https://github.com/CristiRazvi/enum_attributes_validation/blob/master/lib/enum_attributes_validation.rb
+# just removed default message, could do a fork but the gem is really small so easy to include
+module EnumAttributesValidation
+  extend ActiveSupport::Concern
+
+  included do
+    attr_writer :enum_invalid_attributes
+    def enum_invalid_attributes
+      @enum_invalid_attributes ||= {}
+    end
+    validate :check_enum_invalid_attributes
+
+    private
+
+      def check_enum_invalid_attributes
+        if enum_invalid_attributes.present?
+          enum_invalid_attributes.each do |key, opts|
+            if opts[:message]
+              self.errors.add(:base, opts[:message])
+            else
+              self.errors.add(key, :invalid_enum, value: opts[:value], valid_values: self.class.send(key.to_s.pluralize).keys.sort.join(', '))
+            end
+          end
+        end
+      end
+  end
+
+  class_methods do
+    def validate_enum_attributes(*attributes, **opts)
+      attributes.each do |attribute|
+        string_attribute = attribute.to_s
+
+        define_method "#{string_attribute}=" do |argument|
+          if argument.present?
+            string_argument = argument.to_s
+            self[string_attribute]                  = string_argument                    if     self.class.send(string_attribute.pluralize).key?(string_argument)
+            self.enum_invalid_attributes[attribute] = opts.merge(value: string_argument) unless self.class.send(string_attribute.pluralize).key?(string_argument)
+          end
+        end
+      end
+    end
+
+    def validate_enum_attribute(*attributes)
+      self.validate_enum_attributes(*attributes)
+    end
+  end
+end
+
+# include the extension in active record
+ActiveRecord::Base.include EnumAttributesValidation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
       greater_than_or_equal_to: must be greater than or equal to %{count}
       inclusion: is not included in the list
       invalid: is invalid
+      invalid_enum: "can't be %{value}. Valid values are: %{valid_values}"
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
       model_invalid: "Validation failed: %{errors}"


### PR DESCRIPTION
Normally, when assigning wrong enum value Rails raising exception. Here for some models that are used in importer API I will change that to return validation error instead. Found a gem to do that, but instead of forking it or sending PR I just included it in app code as it was small enough.

Now observation tool importers will show better errors.
![image](https://user-images.githubusercontent.com/1286444/129757094-90de8165-7120-4595-95ab-17e22175d605.png)
