### PR TITLE
new naming for observation evidence documents

### DIFF
--- a/app/uploaders/observation_document_uploader.rb
+++ b/app/uploaders/observation_document_uploader.rb
@@ -15,6 +15,22 @@ class ObservationDocumentUploader < CarrierWave::Uploader::Base
     file.present?
   end
 
+  def filename
+    return super if model.observation.nil?
+    return if super.blank?
+
+    filename = if model.name.present?
+                 model.name[0...100]&.parameterize
+               else
+                 [
+                   model.id,
+                   (model.observation.evidence_type || 'other').parameterize
+                 ].join('-')
+               end
+
+    filename + File.extname(super)
+  end
+
   def original_filename
     if file.present?
       file.filename

--- a/lib/tasks/observations.rake
+++ b/lib/tasks/observations.rake
@@ -37,4 +37,15 @@ namespace :observations do
       end
     end
   end
+
+  desc 'Task that will rename existing evidence document files'
+  task rename_evidence_files: :environment do
+    ObservationDocument.find_each do |od|
+      next unless od.attachment?
+
+      od.attachment.recreate_versions!
+      od.save!
+      puts "Evidence document #{od.id} new filename #{od.attachment.filename}"
+    end
+  end
 end


### PR DESCRIPTION
New naming instead of `attachment`. Task to change the exising names.