### PR TITLE
Changed ObserverResource to fetch all fields for the obs-tool

### DIFF
--- a/app/resources/v1/observer_resource.rb
+++ b/app/resources/v1/observer_resource.rb
@@ -3,15 +3,11 @@
 module V1
   class ObserverResource < JSONAPI::Resource
     include CacheableByLocale
-    include Privateable
-    caching
+    #caching
 
     attributes :observer_type, :name, :organization, :is_active, :logo, :address,
                :information_name, :information_email, :information_phone, :data_name,
                :data_email, :data_phone, :organization_type, :delete_logo, :public_info
-
-    privateable :public_info,
-                %w[address information_name information_email information_phone data_email data_phone data_name]
 
     has_many :countries
     has_many :users
@@ -43,6 +39,14 @@ module V1
 
     def self.records(options = {})
       Observer.active
+    end
+
+    def fetchable_fields
+      if context[:app] == 'observations-tool' or @model.public_info
+        super
+      else
+        super - [:address, :information_name, :information_email, :information_phone, :data_email, :data_phone, :data_name]
+      end
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179716381
In the private/my-otp/profile page of the observation tool the observers can't see their own info. It is because the ObserverResource is using the attr public_info as a condition to add/remove to the response those data.
Now that the response depends on the context it shall not be cached anymore.