### PR TITLE
reload operator after changing current score

### DIFF
--- a/app/models/score_operator_document.rb
+++ b/app/models/score_operator_document.rb
@@ -35,7 +35,7 @@ class ScoreOperatorDocument < ApplicationRecord
   def self.recalculate!(operator)
     return if operator.fa_id.blank?
 
-    current_sod = operator.score_operator_document || ScoreOperatorDocument.new
+    current_sod = operator.reload_score_operator_document || ScoreOperatorDocument.new
     current_sod.replace(operator)
   end
 
@@ -78,7 +78,6 @@ class ScoreOperatorDocument < ApplicationRecord
     return update_values(sod) if date == sod.date && persisted?
 
     add_new(sod)
-    operator.reload # specifically reloads operator score_operator_document relation after changing current
   end
 
   def ==(obj)


### PR DESCRIPTION
When approving publication authorization then score is calculated twice, as because document changes states and also operator is approved. The second time, the stale relation for score_operator_document was take for the operator and it couldn't save a new `current` score operator document as there was already one in the DB.