### PR TITLE
Fix subcategories translations edit

### DIFF
--- a/app/admin/subcategory.rb
+++ b/app/admin/subcategory.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Subcategory do
 
   controller do
     def scoped_collection
-      end_of_association_chain.includes([category: :translations])
+      end_of_association_chain.with_translations(I18n.locale).includes([category: :translations])
     end
   end
 

--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -33,8 +33,4 @@ class Subcategory < ApplicationRecord
   scope :by_name_asc, -> { with_translations(I18n.locale).order("subcategory_translations.name ASC") }
 
   ransacker(:name) { Arel.sql("subcategory_translations.name") } # for nested_select in observation form
-
-  default_scope do
-    includes(:translations)
-  end
 end

--- a/app/resources/v1/subcategory_resource.rb
+++ b/app/resources/v1/subcategory_resource.rb
@@ -20,5 +20,9 @@ module V1
     def self.sortable_fields(context)
       super + [:"category.name"]
     end
+
+    def self.apply_includes(records, directives)
+      super.with_translations(I18n.locale)
+    end
   end
 end


### PR DESCRIPTION
Not sure why default scope clashes with `with_translations` but I don't have much time now to investigate this further. Ideally would be to get rid of all default scopes.

Now, all languages are visible.
![image](https://github.com/wri/fti_api/assets/1286444/3d853489-427f-47c6-b742-65633aff98bc)
