### PR TITLE
Observation: add reject action for published observations

### DIFF
--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -70,7 +70,7 @@ ActiveAdmin.register Observation do
   end
 
   member_action :reject, method: [:get, :post] do
-    unless can?(:reject, resource)
+    unless resource.published? && current_user.admin?
       flash[:notice] = I18n.t("active_admin.observations_page.observation_cannot_be_rejected")
       render js: "window.location.reload();" and return
     end
@@ -91,7 +91,7 @@ ActiveAdmin.register Observation do
     end
   end
 
-  action_item :reject, only: :show, if: proc { can?(:reject, resource) } do
+  action_item :reject, only: :show, if: proc { resource.published? && current_user.admin? } do
     link_to I18n.t("active_admin.reject"), reject_admin_observation_path(resource, open_existing: true), remote: true
   end
 

--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -70,7 +70,7 @@ ActiveAdmin.register Observation do
   end
 
   member_action :reject, method: [:get, :post] do
-    unless resource.published? || current_user.admin?
+    unless can?(:reject, resource)
       flash[:notice] = I18n.t("active_admin.observations_page.observation_cannot_be_rejected")
       render js: "window.location.reload();" and return
     end
@@ -91,7 +91,7 @@ ActiveAdmin.register Observation do
     end
   end
 
-  action_item :reject, only: :show, if: proc { resource.published? && current_user.admin? } do
+  action_item :reject, only: :show, if: proc { can?(:reject, resource) } do
     link_to I18n.t("active_admin.reject"), reject_admin_observation_path(resource, open_existing: true), remote: true
   end
 

--- a/app/admin/observation.rb
+++ b/app/admin/observation.rb
@@ -69,6 +69,32 @@ ActiveAdmin.register Observation do
     end
   end
 
+  member_action :reject, method: [:get, :post] do
+    unless resource.published? || current_user.admin?
+      flash[:notice] = I18n.t("active_admin.observations_page.observation_cannot_be_rejected")
+      render js: "window.location.reload();" and return
+    end
+
+    @qc = QualityControl.new(
+      reviewable: resource,
+      reviewer: current_user,
+      passed: false,
+      decision: "Rejected",
+      metadata: {
+        level: "Admin"
+      },
+      comment: params.dig(:quality_control, :comment)
+    )
+    if request.post?
+      @qc.reviewable.skip_status_transition_validation = true
+      @success = @qc.save
+    end
+  end
+
+  action_item :reject, only: :show, if: proc { resource.published? && current_user.admin? } do
+    link_to I18n.t("active_admin.reject"), reject_admin_observation_path(resource, open_existing: true), remote: true
+  end
+
   action_item :start_qc, only: :show, if: proc { resource.validation_status == "Ready for QC2" && resource.responsible_for_qc2.include?(current_user) } do
     link_to I18n.t("active_admin.shared.start_qc"), start_qc_admin_observation_path(observation), method: :put
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,6 +50,7 @@ class Ability
       CountryLink, CountryVpa, RequiredGovDocumentGroup, RequiredGovDocument,
       GovDocument, ScoreOperatorDocument, AboutPageEntry, Page]
     can :read, Observation, is_active: true
+    can :reject, Observation, &:published? if user&.admin?
     can :read, Observer, is_active: true
     can :read, Operator, is_active: true
     can :create, Operator, is_active: false

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,7 +50,6 @@ class Ability
       CountryLink, CountryVpa, RequiredGovDocumentGroup, RequiredGovDocument,
       GovDocument, ScoreOperatorDocument, AboutPageEntry, Page]
     can :read, Observation, is_active: true
-    can :reject, Observation, &:published? if user&.admin?
     can :read, Observer, is_active: true
     can :read, Operator, is_active: true
     can :create, Operator, is_active: false

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -106,6 +106,7 @@ class Observation < ApplicationRecord
 
   attr_accessor :user_type
   attr_accessor :force_translations_from
+  attr_accessor :skip_status_transition_validation
 
   belongs_to :country, inverse_of: :observations
   belongs_to :severity, inverse_of: :observations, optional: true
@@ -143,7 +144,7 @@ class Observation < ApplicationRecord
   validates :lat, numericality: {greater_than_or_equal_to: -90, less_than_or_equal_to: 90, allow_blank: true}
   validates :lng, numericality: {greater_than_or_equal_to: -180, less_than_or_equal_to: 180, allow_blank: true}
   validates :evidence_on_report, presence: true, if: -> { evidence_type == "Evidence presented in the report" }
-  validate :status_changes, if: -> { user_type.present? }
+  validate :status_changes, if: -> { user_type.present? && !skip_status_transition_validation }
   validate :can_set_non_concession_activity, if: -> { non_concession_activity? }
 
   validates :observers, presence: true

--- a/app/views/admin/observations/_reject.html.arb
+++ b/app/views/admin/observations/_reject.html.arb
@@ -1,0 +1,19 @@
+dialog id: dialog_id, title: I18n.t("active_admin.reject") + " " + I18n.t("activerecord.models.observation.one") do
+  active_admin_form_for qc, url: reject_admin_observation_path(resource), method: :post,
+    html: {data: {remote: true}, class: "vertical-form"} do |f|
+    f.semantic_errors(*f.object.errors.attribute_names)
+
+    div class: "flash flash_warning" do
+      I18n.t("active_admin.observations_page.rejected_hint")
+    end
+
+    f.inputs do
+      f.input :comment, as: :text, required: true, input_html: {rows: 4, style: "min-width: 450px;"}
+    end
+
+    f.actions do
+      f.cancel_link "javascript:void(0)", class: "close-dialog-button"
+      f.action :submit, label: I18n.t("active_admin.reject"), button_html: {data: {disable_with: I18n.t("active_admin.rejecting")}}
+    end
+  end
+end

--- a/app/views/admin/observations/reject.js.erb
+++ b/app/views/admin/observations/reject.js.erb
@@ -1,0 +1,9 @@
+<% if @success %>
+  window.location.reload();
+<% else %>
+<%= render "admin/shared/open_dialog",
+  partial: "reject",
+  dialog_id: "observation-reject-dialog",
+  qc: @qc,
+  open_existing: params[:open_existing] %>
+<% end %>

--- a/app/views/admin/shared/_open_dialog.js.erb
+++ b/app/views/admin/shared/_open_dialog.js.erb
@@ -8,7 +8,7 @@
   }
 
   var tmp = document.createElement("div");
-  tmp.innerHTML = "<%= j(render partial, dialog_id: dialog_id) %>";
+  tmp.innerHTML = "<%= j(render partial, **local_assigns) %>";
   document.body.appendChild(tmp.firstElementChild);
 
   var dialog = document.getElementById("<%= j(dialog_id) %>");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,7 @@ en:
       location_on_map: 'Location on map'
       visible: 'Visible'
       scope_hidden: 'Hidden'
+      observation_cannot_be_rejected: 'Observation cannot be rejected'
       rejected_hint: 'The observation will be rejected and the monitor will be notified. The monitor can then edit the observation and submit it for QC again.'
       needs_revision_hint: 'The monitor will be notified that the observation needs revision with proposed suggestions. The monitor can still publish the observation or submit it for QC again.'
     users_page:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -444,6 +444,7 @@ es:
       location_on_map: 'Ubicación en el mapa'
       visible: 'Visible'
       scope_hidden: 'Oculto'
+      observation_cannot_be_rejected: 'La observación no puede ser rechazada'
       rejected_hint: 'La observación será rechazada y el monitor será notificado. El monitor puede luego editar la observación y enviarla nuevamente para QC.'
       needs_revision_hint: 'El monitor será notificado de que la observación necesita revisión con sugerencias propuestas. El monitor aún puede publicar la observación o enviarla nuevamente para QC.'
     users_page:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -437,6 +437,7 @@ fr:
       location_on_map: 'Emplacement sur la carte'
       visible: 'Visible'
       scope_hidden: 'Invisible'
+      observation_cannot_be_rejected: 'L’observation ne peut pas être rejetée'
       rejected_hint: 'L’observation sera rejetée et le moniteur en sera informé. Le moniteur peut ensuite modifier l’observation et la soumettre à nouveau pour le contrôle de qualité.'
       needs_revision_hint: 'Le moniteur sera informé que l’observation nécessite une révision avec des suggestions proposées. Le moniteur peut toujours publier l’observation ou la soumettre à nouveau pour le contrôle de qualité.'
     quality_control_page:

--- a/spec/controllers/admin/observations_controller_spec.rb
+++ b/spec/controllers/admin/observations_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::ObservationsController, type: :controller do
 
         before { get :reject, params: {id: observation.id}, xhr: true, format: :js }
 
-        it "renders the reject form js" do
+        it "renders the reject form js for published observations and admins" do
           expect(response).to be_successful
         end
 

--- a/spec/controllers/admin/observations_controller_spec.rb
+++ b/spec/controllers/admin/observations_controller_spec.rb
@@ -42,6 +42,61 @@ RSpec.describe Admin::ObservationsController, type: :controller do
   end
 
   describe "member actions" do
+    describe "reject" do
+      describe "GET reject" do
+        let(:observation) { create(:observation) }
+
+        before { get :reject, params: {id: observation.id}, xhr: true, format: :js }
+
+        it "renders the reject form js" do
+          expect(response).to be_successful
+        end
+
+        context "when observation is not published and user is not admin" do
+          let(:bo_manager) { create(:bo_manager) }
+          let(:observation) { create(:observation, force_status: "Created") }
+
+          before do
+            sign_in bo_manager
+            get :reject, params: {id: observation.id}, xhr: true, format: :js
+          end
+
+          it "shows a notice and reloads the page" do
+            expect(response).to be_successful
+            expect(flash[:notice]).to eq(I18n.t("active_admin.observations_page.observation_cannot_be_rejected"))
+          end
+        end
+      end
+
+      describe "POST reject" do
+        let(:observation) { create(:observation) }
+
+        before { post :reject, params: {id: observation.id, quality_control: {comment: comment}}, xhr: true, format: :js }
+
+        context "with a comment" do
+          let(:comment) { "Does not meet requirements" }
+
+          it "creates a rejected QualityControl" do
+            expect(response).to be_successful
+            qc = QualityControl.last
+            expect(qc).to be_present
+            expect(qc.passed).to be false
+            expect(qc.decision).to eq("Rejected")
+            expect(qc.comment).to eq(comment)
+            expect(qc.reviewable).to eq(observation)
+          end
+        end
+
+        context "without a comment" do
+          let(:comment) { nil }
+
+          it "does not create a QualityControl" do
+            expect(QualityControl.where(reviewable: observation, decision: "Rejected").count).to eq(0)
+          end
+        end
+      end
+    end
+
     describe "PUT start_qc" do
       let(:observation) { create(:observation, force_status: "Ready for QC2") }
 


### PR DESCRIPTION
Allow admin users to easily reject published observations.

<img width="1021" height="395" alt="image-20260413-112210" src="https://github.com/user-attachments/assets/e7d78158-11e4-49d8-bd54-6d75a4bc8744" />


JIRA: https://gfw.atlassian.net/browse/OPEN-379