### PR TITLE
observations: move obsevations to qc2 when all qc1 reviewers removed

### DIFF
--- a/app/models/observer.rb
+++ b/app/models/observer.rb
@@ -56,6 +56,7 @@ class Observer < ApplicationRecord
   validates :data_email, format: {with: EMAIL_VALIDATOR, if: :data_email?}
 
   before_create :set_responsible_qc2
+  after_update :move_qc1_observations_to_qc2, if: -> { saved_change_to_responsible_qc1_id?(to: nil) }
 
   scope :by_name_asc, -> { order(name: :asc) }
 
@@ -85,5 +86,16 @@ class Observer < ApplicationRecord
     return if responsible_qc2.present?
 
     self.responsible_qc2 = User.where(email: ENV["RESPONSIBLE_EMAIL"].downcase).first
+  end
+
+  def move_qc1_observations_to_qc2
+    observations
+      .includes(:observers)
+      .where(validation_status: ["Ready for QC1", "QC1 in progress"])
+      .find_each do |observation|
+        next if observation.qc1_needed?
+
+        observation.update!(validation_status: "Ready for QC2")
+      end
   end
 end

--- a/spec/models/observer_spec.rb
+++ b/spec/models/observer_spec.rb
@@ -38,6 +38,63 @@ RSpec.describe Observer, type: :model do
     end
   end
 
+  describe "callbacks" do
+    describe "when responsible_qc1 is removed" do
+      let(:qc1_user) { create(:ngo_manager) }
+      let(:observer) { create(:observer, responsible_qc1: qc1_user) }
+
+      def create_observation_in(status)
+        create(:observation, force_status: status).tap do |o|
+          # to override observers taken from observation_report
+          o.observers = [observer]
+        end
+      end
+
+      it "moves `Ready for QC1` observations to `Ready for QC2`" do
+        observation = create_observation_in("Ready for QC1")
+
+        expect {
+          observer.update!(responsible_qc1: nil)
+        }.to change { observation.reload.validation_status }.from("Ready for QC1").to("Ready for QC2")
+      end
+
+      it "moves `QC1 in progress` observations to `Ready for QC2`" do
+        observation = create_observation_in("QC1 in progress")
+
+        expect {
+          observer.update!(responsible_qc1: nil)
+        }.to change { observation.reload.validation_status }.from("QC1 in progress").to("Ready for QC2")
+      end
+
+      it "leaves the observation in QC1 if another observer still has responsible_qc1" do
+        other_observer = create(:observer, responsible_qc1: create(:ngo_manager))
+        observation = create_observation_in("Ready for QC1")
+        observation.observers << other_observer
+
+        expect {
+          observer.update!(responsible_qc1: nil)
+        }.not_to change { observation.reload.validation_status }
+      end
+
+      it "does not touch observations in other statuses" do
+        observation = create_observation_in("Ready for QC2")
+
+        expect {
+          observer.update!(responsible_qc1: nil)
+        }.not_to change { observation.reload.validation_status }
+      end
+
+      it "does nothing when responsible_qc1 is reassigned to another user" do
+        observation = create_observation_in("Ready for QC1")
+        new_qc1 = create(:ngo_manager)
+
+        expect {
+          observer.update!(responsible_qc1: new_qc1)
+        }.not_to change { observation.reload.validation_status }
+      end
+    end
+  end
+
   describe "Class methods" do
     before do
       create_list(:observer, 3)


### PR DESCRIPTION
Moving all QC1 observations to QC2 if there is no QC1 reviewer left.

JIRA: https://gfw.atlassian.net/browse/OPEN-388