### PR TITLE
Fix/long running cache invalidation

### DIFF
--- a/app/jobs/clean_operator_document_cache_job.rb
+++ b/app/jobs/clean_operator_document_cache_job.rb
@@ -1,0 +1,14 @@
+class CleanOperatorDocumentCacheJob < ApplicationJob
+  queue_as :default
+
+  def perform(operator_id)
+    operator = Operator.find_by(id: operator_id)
+    return unless operator
+
+    document_ids = operator.operator_document_ids
+    history_ids = operator.operator_document_history_ids
+
+    Rails.cache.delete_matched(/operator_documents\/(#{document_ids.join("|")})\//) if document_ids.any?
+    Rails.cache.delete_matched(/operator_document_histories\/(#{history_ids.join("|")})\//) if history_ids.any?
+  end
+end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -76,7 +76,7 @@ class Operator < ApplicationRecord
   after_create :create_documents
 
   after_update :recalculate_scores, if: :saved_change_to_approved?
-  after_update :clean_document_cache, if: :saved_change_to_approved?
+  after_update_commit :clean_document_cache, if: :saved_change_to_approved?
   after_update :create_documents, if: -> { saved_change_to_fa_id? && fa_id_before_last_save.blank? }
   after_update :refresh_ranking, if: -> { saved_change_to_fa_id? || saved_change_to_is_active? }
 
@@ -173,9 +173,7 @@ class Operator < ApplicationRecord
   end
 
   def clean_document_cache
-    # TODO: try different technique for jsonapi cache invalidation, this is undocumented way for cleaning cache of jsonapi resources
-    Rails.cache.delete_matched(/operator_documents\/(#{operator_document_ids.join("|")})\//)
-    Rails.cache.delete_matched(/operator_document_histories\/(#{operator_document_history_ids.join("|")})\//)
+    CleanOperatorDocumentCacheJob.perform_later(id)
   end
 
   def refresh_ranking

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,4 +1,53 @@
 {
-  "ignored_warnings": [],
-  "brakeman_version": "7.1.0"
+  "ignored_warnings": [
+    {
+      "warning_type": "Denial of Service",
+      "warning_code": 76,
+      "fingerprint": "0ea03e6b67a9cdf6471ff527b29400cb793da5ab7910df36c03ab9bd8455e63b",
+      "check_name": "RegexDoS",
+      "message": "Model attribute used in regular expression",
+      "file": "app/jobs/clean_operator_document_cache_job.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
+      "code": "/operator_documents\\/(#{Operator.find_by(:id => operator_id).operator_document_ids.join(\"|\")})\\//",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CleanOperatorDocumentCacheJob",
+        "method": "perform"
+      },
+      "user_input": "Operator.find_by(:id => operator_id).operator_document_ids.join(\"|\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        20,
+        185
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Denial of Service",
+      "warning_code": 76,
+      "fingerprint": "7236233b0a2d59f3b79ba3dec11e1a130b4bdfb0bf4efabd33ddd70d0f1095a1",
+      "check_name": "RegexDoS",
+      "message": "Model attribute used in regular expression",
+      "file": "app/jobs/clean_operator_document_cache_job.rb",
+      "line": 12,
+      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
+      "code": "/operator_document_histories\\/(#{Operator.find_by(:id => operator_id).operator_document_history_ids.join(\"|\")})\\//",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CleanOperatorDocumentCacheJob",
+        "method": "perform"
+      },
+      "user_input": "Operator.find_by(:id => operator_id).operator_document_history_ids.join(\"|\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        20,
+        185
+      ],
+      "note": ""
+    }
+  ],
+  "brakeman_version": "8.0.4"
 }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,8 +53,7 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :file_store, Rails.root.join("tmp/cache"), {expires_in: 7.days}
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,27 +9,29 @@ raise "HEALTHCHECKS_ACCOUNT_ID is not set" unless account_id
 unless ENV["SKIP_CRON"] == "true"
   nvm_exec = "NODE_VERSION=default ~/.nvm/nvm-exec"
   check_in = "curl -fsS -m 10 --retry 5 -o /dev/null https://hc-ping.com/#{account_id}/#{env}-:check_in"
-  job_type :rake, "cd :path && :environment_variable=:environment #{nvm_exec} bundle exec rake :task --silent :output && #{check_in}"
+  job_type :rake, "cd :path && :environment_variable=:environment #{nvm_exec} bundle exec rake :task --silent :output"
+  job_type :rake_with_check, "cd :path && :environment_variable=:environment #{nvm_exec} bundle exec rake :task --silent :output && #{check_in}"
   set :output, "#{path}/log/cron.log"
   every 1.day, at: "1 am" do
-    rake "scheduler:expire", check_in: "expire-documents"
-    rake "scheduler:set_active_fmu_operator", check_in: "update-fmus"
-    rake "scheduler:generate_documents_stats", check_in: "generate-documents-stats"
-    rake "scheduler:generate_observation_reports_stats", check_in: "generate-observation-reports-stats"
+    rake_with_check "scheduler:expire", check_in: "expire-documents"
+    rake_with_check "scheduler:set_active_fmu_operator", check_in: "update-fmus"
+    rake_with_check "scheduler:generate_documents_stats", check_in: "generate-documents-stats"
+    rake_with_check "scheduler:generate_observation_reports_stats", check_in: "generate-observation-reports-stats"
+    rake "scheduler:clean_cache"
   end
 
   every 1.hour do
-    rake "observations:hide", check_in: "hide-old-observations"
-    rake "scheduler:calculate_scores", check_in: "calculate"
-    rake "scheduler:create_notifications", check_in: "create-notifications"
+    rake_with_check "observations:hide", check_in: "hide-old-observations"
+    rake_with_check "scheduler:calculate_scores", check_in: "calculate"
+    rake_with_check "scheduler:create_notifications", check_in: "create-notifications"
   end
 
   every 1.day, at: "6 am" do
-    rake "notify_expiration:send", check_in: "notify-about-expired-documents"
+    rake_with_check "notify_expiration:send", check_in: "notify-about-expired-documents"
   end
 
   # send every quarter, on the first day of the month at 8:00
   every "0 8 1 */3 *" do
-    rake "scheduler:send_quarterly_newsletters", check_in: "quarterly-newsletter"
+    rake_with_check "scheduler:send_quarterly_newsletters", check_in: "quarterly-newsletter"
   end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -88,6 +88,15 @@ namespace :scheduler do
     end
     raise "Error while sending quarterly newsletter" if failed
     Rails.logger.info "Sent quarterly newsletters to operators. It took #{time} ms."
-    Rails.logger.info "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+    Rails.logger.info "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+  end
+
+  desc "Delete expired entries from the Rails cache"
+  task clean_cache: :environment do
+    Rails.logger.info "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
+    Rails.logger.info "Going to clean Rails cache at: #{Time.zone.now.strftime("%d/%m/%Y %H:%M")}"
+    time = Benchmark.ms { Rails.cache.cleanup }
+    Rails.logger.info "Rails cache cleaned. It took #{time} ms."
+    Rails.logger.info "::::::::::::::::::::::::::::::::::::::::::::::::::::::::::"
   end
 end

--- a/spec/job/clean_operator_document_cache_job_spec.rb
+++ b/spec/job/clean_operator_document_cache_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe CleanOperatorDocumentCacheJob, type: :job do
+  describe "#perform" do
+    let(:operator) { create(:operator) }
+
+    context "when the operator has documents and histories" do
+      before do
+        allow(Operator).to receive(:find_by).with(id: operator.id).and_return(operator)
+        allow(operator).to receive(:operator_document_ids).and_return([10, 11])
+        allow(operator).to receive(:operator_document_history_ids).and_return([20, 21])
+      end
+
+      it "invalidates cached document and history fragments" do
+        expect(Rails.cache).to receive(:delete_matched)
+          .with(/operator_documents\/(10|11)\//).ordered
+        expect(Rails.cache).to receive(:delete_matched)
+          .with(/operator_document_histories\/(20|21)\//).ordered
+
+        described_class.perform_now(operator.id)
+      end
+    end
+  end
+end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -135,6 +135,32 @@ RSpec.describe Operator, type: :model do
         end
       end
     end
+
+    describe "#clean_document_cache" do
+      let(:operator) { create(:operator, approved: true) }
+
+      it "enqueues a cache cleanup job when approved changes" do
+        expect {
+          operator.update!(approved: false)
+        }.to have_enqueued_job(CleanOperatorDocumentCacheJob).with(operator.id)
+      end
+
+      it "does not enqueue when other attributes change" do
+        operator # create outside the block so the create-time jobs aren't counted
+        expect {
+          operator.update!(website: "https://example.com")
+        }.not_to have_enqueued_job(CleanOperatorDocumentCacheJob)
+      end
+
+      it "does not enqueue when the transaction is rolled back" do
+        expect {
+          ActiveRecord::Base.transaction do
+            operator.update!(approved: false)
+            raise ActiveRecord::Rollback
+          end
+        }.not_to have_enqueued_job(CleanOperatorDocumentCacheJob)
+      end
+    end
   end
 
   describe "Instance methods" do


### PR DESCRIPTION
Sometimes that cache invalidation takes too long, moving to background job. Run cache cleanup every day and set expiration time to 7 days.