### PR TITLE
Feature/api auth refactor

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -9,6 +9,7 @@ class APIController < ActionController::API
   include ActionController::Cookies
   include CanCan::ControllerAdditions
   include JSONAPI::ActsAsResourceController
+  include CsrfProtection
 
   AUTH_COOKIE_NAME = "otp_auth_token"
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -96,11 +96,19 @@ class APIController < ActionController::API
     Auth.decode(bearer_token)&.dig("user")
   end
 
-  # The cookie is encrypted with the app's secret_key_base (opaque, tamper-proof
-  # and with a server-verified expiry) rather than a JWT, so its payload is not
-  # readable by the client. Returns nil for missing/invalid/expired cookies.
+  # The cookie is encrypted with the app's secret_key_base (opaque, tamper-proof)
+  # rather than a JWT, so its payload is not readable by the client. It carries
+  # an exp timestamp that is enforced here, capping how long a cookie is honoured
+  # server-side even if the browser keeps sending it. Returns nil for
+  # missing/invalid/expired cookies.
   def user_id_from_auth_cookie
-    cookies.encrypted[auth_cookie_name]
+    data = cookies.encrypted[auth_cookie_name]
+    return unless data.is_a?(Hash)
+
+    data = data.with_indifferent_access
+    return if data[:exp].blank? || Time.current.to_i > data[:exp].to_i
+
+    data[:user_id]
   end
 
   # each app, like portal and observations tool, has its own auth cookie so a

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -6,8 +6,11 @@ require "auth"
 class APIController < ActionController::API
   class UnprocessableContentError < StandardError; end
 
+  include ActionController::Cookies
   include CanCan::ControllerAdditions
   include JSONAPI::ActsAsResourceController
+
+  AUTH_COOKIE_NAME = "otp_auth_token"
 
   def context
     {current_user: current_user,
@@ -41,11 +44,10 @@ class APIController < ActionController::API
   end
 
   def current_user
-    if auth_present?
-      user = User.find(auth["user"])
-      if user&.is_active
-        @current_user ||= user
-      end
+    @current_user ||= begin
+      id = user_id_from_token
+      user = User.find_by(id: id) if id
+      user if user&.is_active
     end
   rescue
     @current_user = nil
@@ -81,16 +83,35 @@ class APIController < ActionController::API
     render json: json_errors, status: :unprocessable_content
   end
 
-  def token
-    request.env["HTTP_AUTHORIZATION"].scan(/Bearer (.*)$/).flatten.last
+  # Resolve the authenticated user id from either the Bearer JWT (API clients)
+  # or the encrypted session cookie set at login. The Bearer header takes
+  # precedence so an explicit token always wins over a stored cookie.
+  def user_id_from_token
+    user_id_from_bearer_token || user_id_from_auth_cookie
   end
 
-  def auth
-    Auth.decode(token)
+  def user_id_from_bearer_token
+    return unless bearer_token.present?
+
+    Auth.decode(bearer_token)&.dig("user")
   end
 
-  def auth_present?
-    !!request.env.fetch("HTTP_AUTHORIZATION", "").scan("Bearer").flatten.first
+  # The cookie is encrypted with the app's secret_key_base (opaque, tamper-proof
+  # and with a server-verified expiry) rather than a JWT, so its payload is not
+  # readable by the client. Returns nil for missing/invalid/expired cookies.
+  def user_id_from_auth_cookie
+    cookies.encrypted[auth_cookie_name]
+  end
+
+  # each app, like portal and observations tool, has its own auth cookie so a
+  # user can be logged into both at the same time. portal (no app param) uses
+  # the bare name, observations-tool gets an "observations-tool_" prefix.
+  def auth_cookie_name
+    [params[:app], AUTH_COOKIE_NAME].compact.join("_")
+  end
+
+  def bearer_token
+    request.env["HTTP_AUTHORIZATION"]&.scan(/Bearer (.*)$/)&.flatten&.last
   end
 
   def bad_auth_key

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -97,18 +97,12 @@ class APIController < ActionController::API
   end
 
   # The cookie is encrypted with the app's secret_key_base (opaque, tamper-proof)
-  # rather than a JWT, so its payload is not readable by the client. It carries
-  # an exp timestamp that is enforced here, capping how long a cookie is honoured
-  # server-side even if the browser keeps sending it. Returns nil for
-  # missing/invalid/expired cookies.
+  # rather than a JWT, so its payload is not readable by the client. For
+  # remember_me logins Rails embeds a server-verified expiry into the payload
+  # via use_cookies_with_metadata; the default browser-session cookie has no
+  # server-side expiry and is dropped client-side when the browser closes.
   def user_id_from_auth_cookie
-    data = cookies.encrypted[auth_cookie_name]
-    return unless data.is_a?(Hash)
-
-    data = data.with_indifferent_access
-    return if data[:exp].blank? || Time.current.to_i > data[:exp].to_i
-
-    data[:user_id]
+    cookies.encrypted[auth_cookie_name]
   end
 
   # each app, like portal and observations tool, has its own auth cookie so a

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -12,10 +12,12 @@ class APIController < ActionController::API
   include CsrfProtection
 
   AUTH_COOKIE_NAME = "otp_auth_token"
+  # frontends allowed to namespace their own cookies and scope resources via ?app=
+  APPS = %w[observations-tool].freeze
 
   def context
     {current_user: current_user,
-     app: params[:app],
+     app: app_name,
      action: params[:action],
      controller: params[:controller],
      filters: params[:filter],
@@ -46,8 +48,7 @@ class APIController < ActionController::API
 
   def current_user
     @current_user ||= begin
-      id = user_id_from_token
-      user = User.find_by(id: id) if id
+      user = user_from_bearer_token || auth_cookie_user
       user if user&.is_active
     end
   rescue
@@ -84,17 +85,13 @@ class APIController < ActionController::API
     render json: json_errors, status: :unprocessable_content
   end
 
-  # Resolve the authenticated user id from either the Bearer JWT (API clients)
-  # or the encrypted session cookie set at login. The Bearer header takes
-  # precedence so an explicit token always wins over a stored cookie.
-  def user_id_from_token
-    user_id_from_bearer_token || user_id_from_auth_cookie
-  end
-
-  def user_id_from_bearer_token
+  # The Bearer JWT (API clients) takes precedence over the session cookie so an
+  # explicit token always wins over whatever the browser has stored.
+  def user_from_bearer_token
     return unless bearer_token.present?
 
-    Auth.decode(bearer_token)&.dig("user")
+    id = Auth.decode(bearer_token)&.dig("user")
+    User.find_by(id: id) if id
   end
 
   # The cookie is encrypted with the app's secret_key_base (opaque, tamper-proof)
@@ -102,15 +99,31 @@ class APIController < ActionController::API
   # remember_me logins Rails embeds a server-verified expiry into the payload
   # via use_cookies_with_metadata; the default browser-session cookie has no
   # server-side expiry and is dropped client-side when the browser closes.
-  def user_id_from_auth_cookie
-    cookies.encrypted[auth_cookie_name]
+  #
+  # The payload pairs the user id with their authenticatable_salt (derived from
+  # the password digest), so changing a password invalidates every cookie issued
+  # before it without needing a server-side session store.
+  def auth_cookie_user
+    return @auth_cookie_user if defined?(@auth_cookie_user)
+
+    @auth_cookie_user = begin
+      id, salt = cookies.encrypted[auth_cookie_name]
+      user = User.find_by(id: id) if id
+      user if user && ActiveSupport::SecurityUtils.secure_compare(salt.to_s, user.authenticatable_salt.to_s)
+    end
   end
 
   # each app, like portal and observations tool, has its own auth cookie so a
   # user can be logged into both at the same time. portal (no app param) uses
   # the bare name, observations-tool gets an "observations-tool_" prefix.
   def auth_cookie_name
-    [params[:app], AUTH_COOKIE_NAME].compact.join("_")
+    [app_name, AUTH_COOKIE_NAME].compact.join("_")
+  end
+
+  # unknown values fall back to the portal, so a caller can't have an arbitrary
+  # param decide which cookie authenticates them or what a resource scopes to
+  def app_name
+    params[:app].presence_in(APPS)
   end
 
   def bearer_token

--- a/app/controllers/concerns/csrf_protection.rb
+++ b/app/controllers/concerns/csrf_protection.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Double-submit CSRF protection for cookie-authenticated state-changing
+# requests. The XSRF-TOKEN cookie is not HTTP-only so the frontend JS can
+# copy its value into the X-XSRF-TOKEN header on unsafe requests; a
+# cross-site page cannot read the cookie (same-origin policy) and so cannot
+# forge the header. Bearer-authenticated clients and unauthenticated
+# requests are exempt.
+#
+# Depends on the including controller exposing #bearer_token and
+# #user_id_from_auth_cookie.
+module CsrfProtection
+  extend ActiveSupport::Concern
+
+  CSRF_COOKIE_NAME = "XSRF-TOKEN"
+  CSRF_HEADER = "X-XSRF-TOKEN"
+
+  included do
+    before_action :verify_csrf_token!
+  end
+
+  def csrf_cookie_name
+    [params[:app], CSRF_COOKIE_NAME].compact.join("_")
+  end
+
+  protected
+
+  def verify_csrf_token!
+    return if request.get? || request.head? || request.options?
+    return if bearer_token.present?
+    return if user_id_from_auth_cookie.blank?
+
+    expected = cookies[csrf_cookie_name].to_s
+    provided = request.headers[CSRF_HEADER].to_s
+    return if expected.present? && expected.bytesize == provided.bytesize &&
+      ActiveSupport::SecurityUtils.fixed_length_secure_compare(expected, provided)
+
+    # cookie-authed but the XSRF cookie is missing (cleared by the browser,
+    # an extension, etc.) — re-issue one so the frontend can read it and
+    # retry the request. The current request still fails CSRF since the
+    # caller had no token to send. Safe to do under the same-origin policy:
+    # only same-origin JS can read the new cookie.
+    set_csrf_cookie if expected.blank?
+
+    render json: {errors: [{status: 403, title: "Invalid CSRF token"}]}, status: :forbidden
+  end
+
+  # The XSRF-TOKEN cookie is intentionally NOT httponly so the frontend JS can
+  # read it and echo the value back as X-XSRF-TOKEN on unsafe requests;
+  # verify_csrf_token! compares the two using a constant-time check. `expires`
+  # is opt-in so login can match its lifetime to remember_me while the
+  # re-issue path defaults to a browser session cookie.
+  def set_csrf_cookie(expires: nil)
+    cookie = {
+      value: SecureRandom.urlsafe_base64(32),
+      same_site: :strict,
+      secure: Rails.env.production? || Rails.env.staging?,
+      httponly: false
+    }
+    cookie[:expires] = expires if expires
+    cookies[csrf_cookie_name] = cookie
+  end
+end

--- a/app/controllers/concerns/csrf_protection.rb
+++ b/app/controllers/concerns/csrf_protection.rb
@@ -7,20 +7,32 @@
 # forge the header. Bearer-authenticated clients and unauthenticated
 # requests are exempt.
 #
-# Depends on the including controller exposing #bearer_token and
-# #user_id_from_auth_cookie.
+# Depends on the including controller exposing #bearer_token, #auth_cookie_user
+# and #app_name.
 module CsrfProtection
   extend ActiveSupport::Concern
 
   CSRF_COOKIE_NAME = "XSRF-TOKEN"
   CSRF_HEADER = "X-XSRF-TOKEN"
+  CSRF_VERIFIER_SALT = "csrf_token"
 
   included do
     before_action :verify_csrf_token!
   end
 
+  # Same key derivation as Rails.application.message_verifier, but url_safe so
+  # the signed value survives document.cookie unencoded — unlike every other
+  # signed value here, the frontend has to read this one and echo it back.
+  def self.verifier
+    @verifier ||= ActiveSupport::MessageVerifier.new(
+      Rails.application.key_generator.generate_key(CSRF_VERIFIER_SALT),
+      serializer: JSON,
+      url_safe: true
+    )
+  end
+
   def csrf_cookie_name
-    [params[:app], CSRF_COOKIE_NAME].compact.join("_")
+    [app_name, CSRF_COOKIE_NAME].compact.join("_")
   end
 
   protected
@@ -28,36 +40,51 @@ module CsrfProtection
   def verify_csrf_token!
     return if request.get? || request.head? || request.options?
     return if bearer_token.present?
-    return if user_id_from_auth_cookie.blank?
 
-    expected = cookies[csrf_cookie_name].to_s
-    provided = request.headers[CSRF_HEADER].to_s
-    return if expected.present? && expected.bytesize == provided.bytesize &&
-      ActiveSupport::SecurityUtils.fixed_length_secure_compare(expected, provided)
+    user_id = auth_cookie_user&.id
+    return if user_id.blank?
+    return if valid_csrf_token?(user_id)
 
     # cookie-authed but the XSRF cookie is missing (cleared by the browser,
     # an extension, etc.) — re-issue one so the frontend can read it and
     # retry the request. The current request still fails CSRF since the
     # caller had no token to send. Safe to do under the same-origin policy:
     # only same-origin JS can read the new cookie.
-    set_csrf_cookie if expected.blank?
+    set_csrf_cookie(user_id) if cookies[csrf_cookie_name].blank?
 
     render json: {errors: [{status: 403, title: "Invalid CSRF token"}]}, status: :forbidden
   end
 
+  # Cookie and header must match, and the token has to carry a valid signature
+  # over the id of the user the auth cookie resolved to — so a token minted for
+  # one session is not accepted for another.
+  def valid_csrf_token?(user_id)
+    expected = cookies[csrf_cookie_name].to_s
+    provided = request.headers[CSRF_HEADER].to_s
+
+    return false unless expected.present? && expected.bytesize == provided.bytesize &&
+      ActiveSupport::SecurityUtils.fixed_length_secure_compare(expected, provided)
+
+    csrf_verifier.verified(expected)&.dig("user_id") == user_id
+  end
+
   # The XSRF-TOKEN cookie is intentionally NOT httponly so the frontend JS can
-  # read it and echo the value back as X-XSRF-TOKEN on unsafe requests;
-  # verify_csrf_token! compares the two using a constant-time check. `expires`
-  # is opt-in so login can match its lifetime to remember_me while the
+  # read it and echo the value back as X-XSRF-TOKEN on unsafe requests. The
+  # signed value contains no secret; the nonce just rotates it per login.
+  # `expires` is opt-in so login can match its lifetime to remember_me while the
   # re-issue path defaults to a browser session cookie.
-  def set_csrf_cookie(expires: nil)
+  def set_csrf_cookie(user_id, expires: nil)
     cookie = {
-      value: SecureRandom.urlsafe_base64(32),
+      value: csrf_verifier.generate({"user_id" => user_id, "nonce" => SecureRandom.urlsafe_base64(16)}),
       same_site: :strict,
       secure: Rails.env.production? || Rails.env.staging?,
       httponly: false
     }
     cookie[:expires] = expires if expires
     cookies[csrf_cookie_name] = cookie
+  end
+
+  def csrf_verifier
+    CsrfProtection.verifier
   end
 end

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -6,6 +6,13 @@ module V1
 
     include ActionController::Cookies
 
+    # how long the auth cookie stays valid server-side. The default is a browser
+    # session cookie (dropped on browser close) capped at SESSION_TTL so a
+    # captured cookie can't be replayed indefinitely; remember_me persists the
+    # cookie across restarts for REMEMBER_ME_TTL.
+    SESSION_TTL = 24.hours
+    REMEMBER_ME_TTL = 30.days
+
     def create
       @user = User.find_by(email: auth_params[:email])
       if @user.present? && @user.valid_password?(auth_params[:password]) && @user.is_active
@@ -36,17 +43,26 @@ module V1
     private
 
     def auth_params
-      params.expect(auth: [:email, :password, :current_sign_in_ip, :set_cookie])
+      params.expect(auth: [:email, :password, :current_sign_in_ip, :set_cookie, :remember_me])
     end
 
     def set_auth_cookie(user)
-      cookies.encrypted[auth_cookie_name] = {
-        value: user.id,
-        expires: 30.days.from_now,
+      ttl = remember_me? ? REMEMBER_ME_TTL : SESSION_TTL
+      cookie = {
+        value: {user_id: user.id, exp: ttl.from_now.to_i},
         same_site: :strict,
         secure: Rails.env.production? || Rails.env.staging?,
         httponly: true
       }
+      # remember_me makes the browser persist the cookie across restarts;
+      # otherwise it stays a session cookie but is still capped server-side by
+      # the exp baked into the encrypted payload above
+      cookie[:expires] = ttl.from_now if remember_me?
+      cookies.encrypted[auth_cookie_name] = cookie
+    end
+
+    def remember_me?
+      ActiveModel::Type::Boolean.new.cast(auth_params[:remember_me])
     end
 
     def set_download_session_cookie_for(user)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -3,6 +3,9 @@
 module V1
   class SessionsController < APIController
     skip_before_action :authenticate, only: [:create]
+    # login has no prior cookie/header, so CSRF doesn't apply yet — credentials
+    # themselves are the proof of intent
+    skip_before_action :verify_csrf_token!, only: [:create]
 
     include ActionController::Cookies
 
@@ -15,7 +18,10 @@ module V1
         @user.update_column(:should_change_password, true) unless User.strong_password?(auth_params[:password])
         @user.update_tracked_fields!(request)
         set_download_session_cookie_for(@user)
-        set_auth_cookie(@user) if ActiveModel::Type::Boolean.new.cast(auth_params[:set_cookie])
+        if ActiveModel::Type::Boolean.new.cast(auth_params[:set_cookie])
+          set_auth_cookie(@user)
+          set_csrf_cookie(expires: remember_me? ? REMEMBER_ME_TTL.from_now : nil)
+        end
         render json: {token: token, role: @user.user_permission.user_role,
                       user_id: @user.id, country: @user.country_id,
                       operator_ids: @user.operator_ids, observer: @user.observer_id}, status: :ok
@@ -27,6 +33,7 @@ module V1
     def destroy
       cookies.delete(download_user_cookie_name)
       cookies.delete(auth_cookie_name)
+      cookies.delete(csrf_cookie_name)
     end
 
     # each app, like portal and observation tool can have it's own download user cookie to prevent some edgecases

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -13,6 +13,7 @@ module V1
         @user.update_column(:should_change_password, true) unless User.strong_password?(auth_params[:password])
         @user.update_tracked_fields!(request)
         set_download_session_cookie_for(@user)
+        set_auth_cookie(@user) if ActiveModel::Type::Boolean.new.cast(auth_params[:set_cookie])
         render json: {token: token, role: @user.user_permission.user_role,
                       user_id: @user.id, country: @user.country_id,
                       operator_ids: @user.operator_ids, observer: @user.observer_id}, status: :ok
@@ -23,6 +24,7 @@ module V1
 
     def destroy
       cookies.delete(download_user_cookie_name)
+      cookies.delete(auth_cookie_name)
     end
 
     # each app, like portal and observation tool can have it's own download user cookie to prevent some edgecases
@@ -34,7 +36,17 @@ module V1
     private
 
     def auth_params
-      params.expect(auth: [:email, :password, :current_sign_in_ip])
+      params.expect(auth: [:email, :password, :current_sign_in_ip, :set_cookie])
+    end
+
+    def set_auth_cookie(user)
+      cookies.encrypted[auth_cookie_name] = {
+        value: user.id,
+        expires: 30.days.from_now,
+        same_site: :strict,
+        secure: Rails.env.production? || Rails.env.staging?,
+        httponly: true
+      }
     end
 
     def set_download_session_cookie_for(user)

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -6,11 +6,6 @@ module V1
 
     include ActionController::Cookies
 
-    # how long the auth cookie stays valid server-side. The default is a browser
-    # session cookie (dropped on browser close) capped at SESSION_TTL so a
-    # captured cookie can't be replayed indefinitely; remember_me persists the
-    # cookie across restarts for REMEMBER_ME_TTL.
-    SESSION_TTL = 24.hours
     REMEMBER_ME_TTL = 30.days
 
     def create
@@ -47,17 +42,17 @@ module V1
     end
 
     def set_auth_cookie(user)
-      ttl = remember_me? ? REMEMBER_ME_TTL : SESSION_TTL
       cookie = {
-        value: {user_id: user.id, exp: ttl.from_now.to_i},
+        value: user.id,
         same_site: :strict,
         secure: Rails.env.production? || Rails.env.staging?,
         httponly: true
       }
-      # remember_me makes the browser persist the cookie across restarts;
-      # otherwise it stays a session cookie but is still capped server-side by
-      # the exp baked into the encrypted payload above
-      cookie[:expires] = ttl.from_now if remember_me?
+      # remember_me persists the cookie across browser restarts for 30 days
+      # (Rails embeds a server-verified expiry into the encrypted payload via
+      # use_cookies_with_metadata); without it the browser drops the cookie on
+      # close
+      cookie[:expires] = REMEMBER_ME_TTL.from_now if remember_me?
       cookies.encrypted[auth_cookie_name] = cookie
     end
 

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -20,7 +20,7 @@ module V1
         set_download_session_cookie_for(@user)
         if ActiveModel::Type::Boolean.new.cast(auth_params[:set_cookie])
           set_auth_cookie(@user)
-          set_csrf_cookie(expires: remember_me? ? REMEMBER_ME_TTL.from_now : nil)
+          set_csrf_cookie(@user.id, expires: remember_me? ? REMEMBER_ME_TTL.from_now : nil)
         end
         render json: {token: token, role: @user.user_permission.user_role,
                       user_id: @user.id, country: @user.country_id,
@@ -50,7 +50,8 @@ module V1
 
     def set_auth_cookie(user)
       cookie = {
-        value: user.id,
+        # the salt is checked on every request, so a password change drops the cookie
+        value: [user.id, user.authenticatable_salt],
         same_site: :strict,
         secure: Rails.env.production? || Rails.env.staging?,
         httponly: true

--- a/app/resources/concerns/operator_documentable.rb
+++ b/app/resources/concerns/operator_documentable.rb
@@ -114,7 +114,10 @@ module OperatorDocumentable
 
   module ClassMethods
     def apply_includes(records, directives)
-      super.includes(:document_file, :required_operator_document)
+      result = super
+      return result unless result.respond_to?(:includes)
+
+      result.includes(:document_file, :required_operator_document)
     end
   end
 end

--- a/app/resources/v1/observation_resource.rb
+++ b/app/resources/v1/observation_resource.rb
@@ -108,7 +108,10 @@ module V1
     end
 
     def self.apply_includes(records, directives)
-      super.includes(:observation_report, :observation_documents, :translations)
+      result = super
+      return result unless result.respond_to?(:includes)
+
+      result.includes(:observation_report, :observation_documents, :translations)
     end
 
     def validation_status_id

--- a/app/resources/v1/operator_resource.rb
+++ b/app/resources/v1/operator_resource.rb
@@ -109,7 +109,10 @@ module V1
     end
 
     def self.apply_includes(records, directives)
-      super&.includes(:score_operator_document, :score_operator_observation)
+      result = super
+      return result unless result.respond_to?(:includes)
+
+      result.includes(:score_operator_document, :score_operator_observation)
     end
 
     def self.records(options = {})

--- a/app/resources/v1/required_gov_document_group_resource.rb
+++ b/app/resources/v1/required_gov_document_group_resource.rb
@@ -16,7 +16,10 @@ module V1
     end
 
     def self.apply_includes(records, directives)
-      super.with_translations(I18n.locale)
+      result = super
+      return result unless result.respond_to?(:with_translations)
+
+      result.with_translations(I18n.locale)
     end
   end
 end

--- a/app/resources/v1/required_gov_document_resource.rb
+++ b/app/resources/v1/required_gov_document_resource.rb
@@ -30,7 +30,10 @@ module V1
     filters :name, :document_type
 
     def self.apply_includes(records, directives)
-      super.with_translations(I18n.locale)
+      result = super
+      return result unless result.respond_to?(:with_translations)
+
+      result.with_translations(I18n.locale)
     end
   end
 end

--- a/app/resources/v1/subcategory_resource.rb
+++ b/app/resources/v1/subcategory_resource.rb
@@ -22,7 +22,10 @@ module V1
     end
 
     def self.apply_includes(records, directives)
-      super.with_translations(I18n.locale)
+      result = super
+      return result unless result.respond_to?(:with_translations)
+
+      result.with_translations(I18n.locale)
     end
   end
 end

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -7,6 +7,7 @@ module V1
     attributes :name, :first_name, :last_name, :email,
       :is_active, :deactivated_at, :locale, :organization_account,
       :permissions_request, :permissions_accepted, :password, :password_confirmation,
+      :operator_ids, :observer_id, :country_id,
       :managed_observer_ids, :qc1_observer_ids, :qc2_observer_ids
 
     has_one :country

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,7 +4,7 @@ if Rails.env.development? || Rails.env.e2e?
   Rails.application.config.middleware.insert_before 0, Rack::Cors do
     allow do
       origins(/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/)
-      resource "*", headers: :any, methods: %i[get post put patch delete options head]
+      resource "*", headers: :any, methods: %i[get post put patch delete options head], credentials: true
     end
   end
 end

--- a/spec/integration/v1/sessions_spec.rb
+++ b/spec/integration/v1/sessions_spec.rb
@@ -33,6 +33,82 @@ module V1
       expect(user.reload.should_change_password).to eq(true)
     end
 
+    describe "Auth cookie" do
+      it "does not set auth cookie by default" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1"}}
+
+        expect(status).to eq(200)
+        expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_nil
+      end
+
+      it "sets an opaque auth cookie when set_cookie param is true" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        expect(status).to eq(200)
+        cookie = response.cookies[APIController::AUTH_COOKIE_NAME]
+        expect(cookie).to be_present
+        # the cookie is encrypted, so it neither exposes the user id nor is a JWT
+        expect(cookie).not_to include(user.id.to_s)
+        expect(cookie).not_to eq(JWT.encode({user: user.id}, ENV["AUTH_SECRET"], "HS256"))
+      end
+
+      it "sets a separate auth cookie per app" do
+        post "/login?app=observations-tool", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        expect(status).to eq(200)
+        expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_nil
+        expect(response.cookies["observations-tool_#{APIController::AUTH_COOKIE_NAME}"]).to be_present
+      end
+
+      it "authenticates a request using the auth cookie" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user"
+
+        expect(status).to eq(200)
+        expect(parsed_attributes[:email]).to eq(user.email)
+      end
+
+      it "authenticates a request using the app-namespaced auth cookie" do
+        post "/login?app=observations-tool", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user?app=observations-tool"
+
+        expect(status).to eq(200)
+        expect(parsed_attributes[:email]).to eq(user.email)
+      end
+
+      it "does not authenticate when the app does not match the cookie" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        # cookie was set for the portal (no app), so the observations-tool app
+        # cannot read it
+        get "/users/current-user?app=observations-tool"
+
+        expect(status).to eq(401)
+      end
+
+      it "Authorization header takes precedence over cookie" do
+        other_user = create(:admin)
+        post "/login", params: {auth: {email: other_user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user", headers: user_headers
+
+        expect(status).to eq(200)
+        expect(parsed_attributes[:email]).to eq(user.email)
+      end
+
+      it "logout clears the auth cookie" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+        expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_present
+
+        delete "/logout"
+
+        expect(status).to eq(204)
+        expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_blank
+      end
+    end
+
     describe "Download session" do
       it "Destroy session removes download cookie" do
         post "/sessions/download-session", headers: user_headers

--- a/spec/integration/v1/sessions_spec.rb
+++ b/spec/integration/v1/sessions_spec.rb
@@ -60,6 +60,44 @@ module V1
         expect(response.cookies["observations-tool_#{APIController::AUTH_COOKIE_NAME}"]).to be_present
       end
 
+      it "sets a session cookie (no expiry) by default" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        expect(status).to eq(200)
+        set_cookie = auth_set_cookie_header
+        expect(set_cookie).to be_present
+        expect(set_cookie).not_to match(/expires=/i)
+        expect(set_cookie).not_to match(/max-age=/i)
+      end
+
+      it "sets a persistent cookie when remember_me is true" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true, remember_me: true}}
+
+        expect(status).to eq(200)
+        expect(auth_set_cookie_header).to match(/expires=/i)
+      end
+
+      it "stops honouring a session cookie after its server-side expiry" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user"
+        expect(status).to eq(200)
+
+        travel(V1::SessionsController::SESSION_TTL + 1.hour) do
+          get "/users/current-user"
+          expect(status).to eq(401)
+        end
+      end
+
+      it "honours a remember_me cookie past the default session window" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true, remember_me: true}}
+
+        travel(V1::SessionsController::SESSION_TTL + 1.hour) do
+          get "/users/current-user"
+          expect(status).to eq(200)
+        end
+      end
+
       it "authenticates a request using the auth cookie" do
         post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
 

--- a/spec/integration/v1/sessions_spec.rb
+++ b/spec/integration/v1/sessions_spec.rb
@@ -47,8 +47,7 @@ module V1
         expect(status).to eq(200)
         cookie = response.cookies[APIController::AUTH_COOKIE_NAME]
         expect(cookie).to be_present
-        # the cookie is encrypted, so it neither exposes the user id nor is a JWT
-        expect(cookie).not_to include(user.id.to_s)
+        # the cookie is encrypted, not a raw JWT
         expect(cookie).not_to eq(JWT.encode({user: user.id}, ENV["AUTH_SECRET"], "HS256"))
       end
 
@@ -75,27 +74,6 @@ module V1
 
         expect(status).to eq(200)
         expect(auth_set_cookie_header).to match(/expires=/i)
-      end
-
-      it "stops honouring a session cookie after its server-side expiry" do
-        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
-
-        get "/users/current-user"
-        expect(status).to eq(200)
-
-        travel(V1::SessionsController::SESSION_TTL + 1.hour) do
-          get "/users/current-user"
-          expect(status).to eq(401)
-        end
-      end
-
-      it "honours a remember_me cookie past the default session window" do
-        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true, remember_me: true}}
-
-        travel(V1::SessionsController::SESSION_TTL + 1.hour) do
-          get "/users/current-user"
-          expect(status).to eq(200)
-        end
       end
 
       it "authenticates a request using the auth cookie" do
@@ -196,7 +174,10 @@ module V1
           "permissions-accepted": nil,
           "managed-observer-ids": [],
           "qc1-observer-ids": [],
-          "qc2-observer-ids": []
+          "qc2-observer-ids": [],
+          "operator-ids": [],
+          "country-id": nil,
+          "observer-id": nil
         })
       end
 

--- a/spec/integration/v1/sessions_spec.rb
+++ b/spec/integration/v1/sessions_spec.rb
@@ -118,10 +118,80 @@ module V1
         post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
         expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_present
 
-        delete "/logout"
+        delete "/logout", headers: {APIController::CSRF_HEADER => cookies[APIController::CSRF_COOKIE_NAME]}
 
         expect(status).to eq(204)
         expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_blank
+      end
+    end
+
+    describe "CSRF protection" do
+      it "issues a non-HTTP-only XSRF-TOKEN cookie at login" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        expect(response.cookies[APIController::CSRF_COOKIE_NAME]).to be_present
+        csrf_set_cookie = Array(response.headers["Set-Cookie"]).find { |c| c.start_with?("#{APIController::CSRF_COOKIE_NAME}=") }
+        expect(csrf_set_cookie).not_to match(/httponly/i)
+      end
+
+      it "blocks cookie-authenticated unsafe requests without the CSRF header" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        delete "/logout"
+
+        expect(status).to eq(403)
+      end
+
+      it "blocks cookie-authenticated unsafe requests with a mismatched CSRF header" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        delete "/logout", headers: {APIController::CSRF_HEADER => "not-the-real-token"}
+
+        expect(status).to eq(403)
+      end
+
+      it "allows cookie-authenticated unsafe requests when the header matches" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        delete "/logout", headers: {APIController::CSRF_HEADER => cookies[APIController::CSRF_COOKIE_NAME]}
+
+        expect(status).to eq(204)
+      end
+
+      it "exempts safe (GET) cookie-authenticated requests from CSRF" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user"
+
+        expect(status).to eq(200)
+      end
+
+      it "exempts Bearer-authenticated requests from CSRF" do
+        delete "/logout", headers: user_headers
+
+        expect(status).to eq(204)
+      end
+
+      it "re-issues the XSRF-TOKEN cookie when it's missing on a cookie-authed request" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        # simulate the XSRF cookie being cleared while the auth cookie persists
+        cookies.delete(APIController::CSRF_COOKIE_NAME)
+
+        delete "/logout"
+
+        # the current request still fails CSRF (no header could be sent)...
+        expect(status).to eq(403)
+        # ...but the response includes a fresh XSRF cookie so the frontend can retry
+        expect(response.cookies[APIController::CSRF_COOKIE_NAME]).to be_present
+      end
+
+      it "logout clears the XSRF-TOKEN cookie" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        delete "/logout", headers: {APIController::CSRF_HEADER => cookies[APIController::CSRF_COOKIE_NAME]}
+
+        expect(response.cookies[APIController::CSRF_COOKIE_NAME]).to be_blank
       end
     end
 

--- a/spec/integration/v1/sessions_spec.rb
+++ b/spec/integration/v1/sessions_spec.rb
@@ -94,6 +94,26 @@ module V1
         expect(parsed_attributes[:email]).to eq(user.email)
       end
 
+      it "ignores an unknown app and falls back to the portal cookie" do
+        post "/login?app=bogus", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        expect(status).to eq(200)
+        expect(response.cookies["bogus_#{APIController::AUTH_COOKIE_NAME}"]).to be_nil
+        expect(response.cookies[APIController::AUTH_COOKIE_NAME]).to be_present
+      end
+
+      it "stops authenticating once the password changes" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        get "/users/current-user"
+        expect(status).to eq(200)
+
+        user.update!(password: "Supersecret2", password_confirmation: "Supersecret2")
+
+        get "/users/current-user"
+        expect(status).to eq(401)
+      end
+
       it "does not authenticate when the app does not match the cookie" do
         post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
 
@@ -134,6 +154,15 @@ module V1
         expect(csrf_set_cookie).not_to match(/httponly/i)
       end
 
+      it "issues a URL-safe token so the frontend can echo it back verbatim" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        csrf_set_cookie = Array(response.headers["Set-Cookie"]).find { |c| c.start_with?("#{APIController::CSRF_COOKIE_NAME}=") }
+        value = csrf_set_cookie.split("=", 2).last.split(";").first
+        # no percent-encoding in the raw header means document.cookie needs no decoding
+        expect(value).to match(/\A[A-Za-z0-9_-]+--[a-f0-9]+\z/)
+      end
+
       it "blocks cookie-authenticated unsafe requests without the CSRF header" do
         post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
 
@@ -156,6 +185,28 @@ module V1
         delete "/logout", headers: {APIController::CSRF_HEADER => cookies[APIController::CSRF_COOKIE_NAME]}
 
         expect(status).to eq(204)
+      end
+
+      it "rejects a matching cookie and header that is not signed by the app" do
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        forged = "not-a-signed-token"
+        cookies[APIController::CSRF_COOKIE_NAME] = forged
+        delete "/logout", headers: {APIController::CSRF_HEADER => forged}
+
+        expect(status).to eq(403)
+      end
+
+      it "rejects a token signed for another user" do
+        other_user = create(:admin)
+        post "/login", params: {auth: {email: user.email, password: "Supersecret1", set_cookie: true}}
+
+        other_token = CsrfProtection.verifier
+          .generate({"user_id" => other_user.id, "nonce" => SecureRandom.urlsafe_base64(16)})
+        cookies[APIController::CSRF_COOKIE_NAME] = other_token
+        delete "/logout", headers: {APIController::CSRF_HEADER => other_token}
+
+        expect(status).to eq(403)
       end
 
       it "exempts safe (GET) cookie-authenticated requests from CSRF" do

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -82,6 +82,12 @@ module IntegrationHelper
     }
   end
 
+  # the raw Set-Cookie header entry for the auth cookie, so expiry attributes
+  # (expires/max-age) can be asserted on
+  def auth_set_cookie_header
+    Array(response.headers["Set-Cookie"]).find { |c| c.start_with?("#{APIController::AUTH_COOKIE_NAME}=") }
+  end
+
   def initialize_download_session(user_headers, app: nil)
     url = "/sessions/download-session"
     url += "?app=#{app}" if app.present?


### PR DESCRIPTION
Add cookie-based auth to API. Frontend apps are using the same domain, and Angular app is SPA and cookies are the most secure way of storing user authentication.

JIRA: https://gfw.atlassian.net/browse/OPEN-389