### PR TITLE
Feature/New DRC concession types

### DIFF
--- a/app/admin/fmu.rb
+++ b/app/admin/fmu.rb
@@ -119,7 +119,9 @@ ActiveAdmin.register Fmu do
     attributes_table do
       row :id
       row :name
-      row :forest_type
+      row :forest_type do |r|
+        ForestType.label(r.forest_type)
+      end
       row :country
       row :operator
 
@@ -179,7 +181,7 @@ ActiveAdmin.register Fmu do
           f.input :name
           f.input :country, input_html: {disabled: object.persisted?}, required: true
           f.input :forest_type, as: :select,
-            collection: ForestType::TYPES.map { |key, v| [v[:label], key] },
+            collection: ForestType::TYPES.map { |key, _v| [ForestType.label(key), key] },
             input_html: {disabled: object.persisted? && object.country&.iso != "COD"}
           li class: "checkboxes_label" do
             label I18n.t("active_admin.fmus_page.certification")

--- a/app/admin/fmu.rb
+++ b/app/admin/fmu.rb
@@ -180,7 +180,7 @@ ActiveAdmin.register Fmu do
           f.input :country, input_html: {disabled: object.persisted?}, required: true
           f.input :forest_type, as: :select,
             collection: ForestType::TYPES.map { |key, v| [v[:label], key] },
-            input_html: {disabled: object.persisted?}
+            input_html: {disabled: object.persisted? && object.country&.iso != "COD"}
           li class: "checkboxes_label" do
             label I18n.t("active_admin.fmus_page.certification")
           end

--- a/app/admin/fmu.rb
+++ b/app/admin/fmu.rb
@@ -183,6 +183,11 @@ ActiveAdmin.register Fmu do
           f.input :forest_type, as: :select,
             collection: ForestType::TYPES.map { |key, _v| [ForestType.label(key), key] },
             input_html: {disabled: object.persisted? && object.country&.iso != "COD"}
+          li id: "forest_type_warning", class: "input", style: "display: none;" do
+            div class: "flash flash_warning" do
+              I18n.t("active_admin.fmus_page.forest_type_warning")
+            end
+          end
           li class: "checkboxes_label" do
             label I18n.t("active_admin.fmus_page.certification")
           end

--- a/app/admin/fmu.rb
+++ b/app/admin/fmu.rb
@@ -152,6 +152,7 @@ ActiveAdmin.register Fmu do
     selectable_column
     column :id, sortable: true
     column :name, sortable: true
+    column :forest_type
     column :country, sortable: "country_translations.name"
     column :operator
     column "FSC", :certification_fsc

--- a/app/admin/observations_dashboard.rb
+++ b/app/admin/observations_dashboard.rb
@@ -68,7 +68,7 @@ ActiveAdmin.register ObservationStatistic, as: "Observations Dashboard" do
       if r.fmu_forest_type.nil?
         I18n.t("active_admin.producer_documents_dashboard_page.all_forest_types")
       else
-        ForestType::TYPES[r.fmu_forest_type][:label]
+        ForestType.label(r.fmu_forest_type)
       end
     end
     column :severity_level, sortable: false do |r|
@@ -176,7 +176,7 @@ ActiveAdmin.register ObservationStatistic, as: "Observations Dashboard" do
       if r.fmu_forest_type.nil?
         I18n.t("active_admin.producer_documents_dashboard_page.all_forest_types")
       else
-        ForestType::TYPES[r.fmu_forest_type][:label]
+        ForestType.label(r.fmu_forest_type)
       end
     end
     column :validation_status do |r|

--- a/app/admin/operator_documents_dashboard.rb
+++ b/app/admin/operator_documents_dashboard.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register OperatorDocumentStatistic, as: "Producer Documents Dashboar
       if r.fmu_forest_type.nil?
         I18n.t("active_admin.producer_documents_dashboard_page.all_forest_types")
       else
-        ForestType::TYPES[r.fmu_forest_type][:label]
+        ForestType.label(r.fmu_forest_type)
       end
     end
     column :document_type do |r|
@@ -115,7 +115,7 @@ ActiveAdmin.register OperatorDocumentStatistic, as: "Producer Documents Dashboar
       if r.fmu_forest_type.nil?
         I18n.t("active_admin.producer_documents_dashboard_page.all_forest_types")
       else
-        ForestType::TYPES[r.fmu_forest_type][:label]
+        ForestType.label(r.fmu_forest_type)
       end
     end
     column :document_type do |r|

--- a/app/assets/javascripts/fmu.js
+++ b/app/assets/javascripts/fmu.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
 
 function updateFmuFields() {
   const countryList = {
-    7: ['cdc', 'cdcf'],
+    7: ['cdc', 'ccf'],
     45: ['ufa', 'cf', 'vdc'],
     53: ['cpaet', 'cfad']
   }

--- a/app/assets/javascripts/fmu.js
+++ b/app/assets/javascripts/fmu.js
@@ -7,6 +7,14 @@ $(document).ready(function() {
   $('#fmu_country_id').on('change', function(){
     updateFmuFields();
   })
+
+  const warning = $('#forest_type_warning');
+  if (warning.length > 0 && $('body').hasClass('edit')) {
+    const initialValue = forestType.val();
+    forestType.on('change', function() {
+      warning.toggle(forestType.val() !== initialValue);
+    })
+  }
 })
 
 function updateFmuFields() {

--- a/app/assets/javascripts/fmu.js
+++ b/app/assets/javascripts/fmu.js
@@ -11,11 +11,13 @@ $(document).ready(function() {
 
 function updateFmuFields() {
   const countryList = {
+    7: ['cdc', 'cdcf'],
     45: ['ufa', 'cf', 'vdc'],
     53: ['cpaet', 'cfad']
   }
   var forestTypes = $('#fmu_forest_type:not([type="checkbox"])');
   var country = $('#fmu_country_id').val();
+  var currentValue = forestTypes.val();
 
   if (country in countryList) {
     forestTypes.prop('disabled', false);
@@ -33,6 +35,8 @@ function updateFmuFields() {
     forestTypes.prop('disabled', true);
   }
 
-  forestTypes.val([])
+  if (!(country in countryList) || !countryList[country].includes(currentValue)) {
+    forestTypes.val([])
+  }
   forestTypes.select2({width: '80%'}).trigger('change')
 }

--- a/app/models/concerns/array_forest_typeable.rb
+++ b/app/models/concerns/array_forest_typeable.rb
@@ -13,7 +13,7 @@ module ArrayForestTypeable
     end
 
     def forest_types
-      super.map { |x| ForestType::TYPES.select { |_, h| h[:index] == x }.keys[0] }
+      (super || []).map { |x| ForestType::TYPES.select { |_, h| h[:index] == x }.keys[0] }
     end
 
     def forest_types=(array)

--- a/app/models/fmu.rb
+++ b/app/models/fmu.rb
@@ -52,6 +52,7 @@ class Fmu < ApplicationRecord
 
   after_create :update_geometry, if: :geojson
   after_update :update_geometry, if: :saved_change_to_geojson?
+  after_update :sync_operator_documents, if: :saved_change_to_forest_type?
   after_save :update_geojson_properties
 
   # TODO Redo all of those
@@ -141,6 +142,10 @@ class Fmu < ApplicationRecord
       matches.any? ? matches : nil
     } do |parent|
     parent.table[:id]
+  end
+
+  def sync_operator_documents
+    fmu_operator&.update_documents_list
   end
 
   def update_geometry

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -114,7 +114,7 @@ class FmuOperator < ApplicationRecord
 
       # Only the RODF for this fmu's forest_type should be created, empty forest_types means the document applies to all FMUs
       required_documents = RequiredOperatorDocumentFmu.where(
-        "country_id = :country_id AND (forest_types = '{}' OR :forest_type = ANY (forest_types))",
+        "country_id = :country_id AND (COALESCE(cardinality(forest_types), 0) = 0 OR :forest_type = ANY (forest_types))",
         country_id: fmu.country_id, forest_type: Fmu.forest_types[fmu.forest_type]
       )
 

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -112,11 +112,13 @@ class FmuOperator < ApplicationRecord
       # commit current transaction
       next if current_operator.blank? || current_operator.fa_id.blank?
 
-      # Only the RODF for this fmu's forest_type should be created
-      rodf_query = "country_id = #{fmu.country_id} "
-      rodf_query += " AND '#{Fmu.forest_types[fmu.forest_type]}' = ANY (forest_types)" if fmu.forest_type != "fmu"
+      # Only the RODF for this fmu's forest_type should be created, empty forest_types means the document applies to all FMUs
+      required_documents = RequiredOperatorDocumentFmu.where(
+        "country_id = :country_id AND (forest_types = '{}' OR :forest_type = ANY (forest_types))",
+        country_id: fmu.country_id, forest_type: Fmu.forest_types[fmu.forest_type]
+      )
 
-      RequiredOperatorDocumentFmu.where(rodf_query).find_each do |rodf|
+      required_documents.find_each do |rodf|
         OperatorDocumentFmu.where(required_operator_document_id: rodf.id,
           operator_id: current_operator.id,
           fmu_id: fmu_id).first_or_create do |odf|

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -98,8 +98,18 @@ class FmuOperator < ApplicationRecord
     current_operator = self&.fmu&.reload&.operator
 
     OperatorDocumentFmu.transaction do
+      # Only the RODF for this fmu's forest_type should be created, empty forest_types means the document applies to all FMUs
+      required_documents = RequiredOperatorDocumentFmu.where(
+        "country_id = :country_id AND (COALESCE(cardinality(forest_types), 0) = 0 OR :forest_type = ANY (forest_types))",
+        country_id: fmu.country_id, forest_type: Fmu.forest_types[fmu.forest_type]
+      )
+
       to_destroy = OperatorDocumentFmu.includes(:operator).where(fmu_id: fmu_id)
-      to_destroy = to_destroy.where.not(operator_id: current_operator.id) if current_operator.present?
+      if current_operator.present?
+        to_destroy = to_destroy
+          .where.not(operator_id: current_operator.id)
+          .or(to_destroy.where.not(required_operator_document_id: required_documents.select(:id)))
+      end
       destroyed_count = to_destroy.count
       to_destroy.each do |doc|
         doc.skip_score_recalculation = true # just do it once for each operator at the end
@@ -107,16 +117,10 @@ class FmuOperator < ApplicationRecord
       end
       to_destroy.map(&:operator).uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
 
-      Rails.logger.info "Destroyed #{destroyed_count} documents for FMU #{fmu_id} that don't belong to #{current_operator&.id}"
+      Rails.logger.info "Destroyed #{destroyed_count} documents for FMU #{fmu_id} that don't belong to #{current_operator&.id} or no longer match the forest type"
 
       # commit current transaction
       next if current_operator.blank? || current_operator.fa_id.blank?
-
-      # Only the RODF for this fmu's forest_type should be created, empty forest_types means the document applies to all FMUs
-      required_documents = RequiredOperatorDocumentFmu.where(
-        "country_id = :country_id AND (COALESCE(cardinality(forest_types), 0) = 0 OR :forest_type = ANY (forest_types))",
-        country_id: fmu.country_id, forest_type: Fmu.forest_types[fmu.forest_type]
-      )
 
       required_documents.find_each do |rodf|
         OperatorDocumentFmu.where(required_operator_document_id: rodf.id,

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -100,8 +100,10 @@ class FmuOperator < ApplicationRecord
     current_operator = fmu.reload.operator
 
     OperatorDocumentFmu.transaction do
+      # FMUs in non-active countries use the generic required documents (country_id is null)
+      documents_country_id = Country.active.exists?(id: fmu.country_id) ? fmu.country_id : nil
       required_documents = RequiredOperatorDocumentFmu
-        .where(country_id: fmu.country_id)
+        .where(country_id: documents_country_id)
         .for_forest_type(fmu.forest_type)
 
       to_destroy = OperatorDocumentFmu.includes(:operator).where(fmu_id: fmu_id)

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -119,6 +119,7 @@ class FmuOperator < ApplicationRecord
       Rails.logger.info "Destroyed #{to_destroy.size} documents for FMU #{fmu_id} that don't belong to #{current_operator&.id} or no longer match the forest type"
 
       if current_operator.present? && current_operator.fa_id.present?
+        created_count = 0
         required_documents.find_each do |required_document|
           OperatorDocumentFmu.where(
             required_operator_document_id: required_document.id,
@@ -127,13 +128,17 @@ class FmuOperator < ApplicationRecord
           ).first_or_create do |document|
             document.skip_score_recalculation = true
             document.status = OperatorDocument.statuses[:doc_not_provided]
+            created_count += 1
           end
         end
-        operators_to_recalculate << current_operator
-        Rails.logger.info "Created the documents for operator #{current_operator.id} and FMU #{fmu_id}"
+        operators_to_recalculate << current_operator if created_count > 0
+        Rails.logger.info "Created #{created_count} documents for operator #{current_operator.id} and FMU #{fmu_id}"
       end
 
-      operators_to_recalculate.uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
+      operators_to_recalculate.uniq.each do |operator|
+        ScoreOperatorDocument.recalculate!(operator)
+        Rails.logger.info "Recalculated scores for operator #{operator.id}"
+      end
     end
   end
 

--- a/app/models/fmu_operator.rb
+++ b/app/models/fmu_operator.rb
@@ -93,16 +93,16 @@ class FmuOperator < ApplicationRecord
     end
   end
 
-  # Updates the list of documents for this FMU, TODO: move it to some service object
+  # Updates the list of documents for this FMU
   def update_documents_list
-    current_operator = self&.fmu&.reload&.operator
+    return if fmu_id.blank?
+
+    current_operator = fmu.reload.operator
 
     OperatorDocumentFmu.transaction do
-      # Only the RODF for this fmu's forest_type should be created, empty forest_types means the document applies to all FMUs
-      required_documents = RequiredOperatorDocumentFmu.where(
-        "country_id = :country_id AND (COALESCE(cardinality(forest_types), 0) = 0 OR :forest_type = ANY (forest_types))",
-        country_id: fmu.country_id, forest_type: Fmu.forest_types[fmu.forest_type]
-      )
+      required_documents = RequiredOperatorDocumentFmu
+        .where(country_id: fmu.country_id)
+        .for_forest_type(fmu.forest_type)
 
       to_destroy = OperatorDocumentFmu.includes(:operator).where(fmu_id: fmu_id)
       if current_operator.present?
@@ -110,28 +110,30 @@ class FmuOperator < ApplicationRecord
           .where.not(operator_id: current_operator.id)
           .or(to_destroy.where.not(required_operator_document_id: required_documents.select(:id)))
       end
-      destroyed_count = to_destroy.count
-      to_destroy.each do |doc|
-        doc.skip_score_recalculation = true # just do it once for each operator at the end
-        doc.destroy
+
+      operators_to_recalculate = to_destroy.map(&:operator).uniq
+      to_destroy.each do |document|
+        document.skip_score_recalculation = true # just do it once for each operator at the end
+        document.destroy
       end
-      to_destroy.map(&:operator).uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
+      Rails.logger.info "Destroyed #{to_destroy.size} documents for FMU #{fmu_id} that don't belong to #{current_operator&.id} or no longer match the forest type"
 
-      Rails.logger.info "Destroyed #{destroyed_count} documents for FMU #{fmu_id} that don't belong to #{current_operator&.id} or no longer match the forest type"
-
-      # commit current transaction
-      next if current_operator.blank? || current_operator.fa_id.blank?
-
-      required_documents.find_each do |rodf|
-        OperatorDocumentFmu.where(required_operator_document_id: rodf.id,
-          operator_id: current_operator.id,
-          fmu_id: fmu_id).first_or_create do |odf|
-          odf.skip_score_recalculation = true # just do it once at the end
-          odf.update!(status: OperatorDocument.statuses[:doc_not_provided]) unless odf.persisted?
+      if current_operator.present? && current_operator.fa_id.present?
+        required_documents.find_each do |required_document|
+          OperatorDocumentFmu.where(
+            required_operator_document_id: required_document.id,
+            operator_id: current_operator.id,
+            fmu_id: fmu_id
+          ).first_or_create do |document|
+            document.skip_score_recalculation = true
+            document.status = OperatorDocument.statuses[:doc_not_provided]
+          end
         end
+        operators_to_recalculate << current_operator
+        Rails.logger.info "Created the documents for operator #{current_operator.id} and FMU #{fmu_id}"
       end
-      ScoreOperatorDocument.recalculate!(current_operator)
-      Rails.logger.info "Create the documents for operator #{current_operator.id} and FMU #{fmu_id}"
+
+      operators_to_recalculate.uniq.each { |operator| ScoreOperatorDocument.recalculate!(operator) }
     end
   end
 
@@ -142,6 +144,6 @@ class FmuOperator < ApplicationRecord
     return if end_date && (end_date < Time.zone.today)
     return if start_date > Time.zone.today
 
-    fmu.save
+    fmu.reload.save
   end
 end

--- a/app/models/forest_type.rb
+++ b/app/models/forest_type.rb
@@ -6,7 +6,9 @@ class ForestType
     vdc: {index: 3, label: "Vente de Coupe", geojson_label: "ventes_de_coupe"},
     cpaet: {index: 4, label: "CPAET", geojson_label: "CPAET"},
     cfad: {index: 5, label: "CFAD", geojson_label: "CFAD"},
-    pea: {index: 6, label: "PEA", geojson_label: "PEA"}
+    pea: {index: 6, label: "PEA", geojson_label: "PEA"},
+    cdc: {index: 7, label: "Concession de conservation", geojson_label: "cdc"},
+    cdcf: {index: 8, label: "Concession de concession forestière", geojson_label: "cdcf"}
   }.with_indifferent_access.freeze
   TYPES_WITH_CODE = TYPES.map { |k, v| {k => v[:index]} }.reduce({}, :merge).with_indifferent_access
 

--- a/app/models/forest_type.rb
+++ b/app/models/forest_type.rb
@@ -1,18 +1,22 @@
 class ForestType
   TYPES = {
-    fmu: {index: 0, label: "FMU", geojson_label: ""},
-    ufa: {index: 1, label: "UFA", geojson_label: "ufa"},
-    cf: {index: 2, label: "Communal Forest", geojson_label: "communal"},
-    vdc: {index: 3, label: "Vente de Coupe", geojson_label: "ventes_de_coupe"},
-    cpaet: {index: 4, label: "CPAET", geojson_label: "CPAET"},
-    cfad: {index: 5, label: "CFAD", geojson_label: "CFAD"},
-    pea: {index: 6, label: "PEA", geojson_label: "PEA"},
-    cdc: {index: 7, label: "Concession de conservation", geojson_label: "cdc"},
-    ccf: {index: 8, label: "Concession de concession forestière", geojson_label: "ccf"}
+    fmu: {index: 0, geojson_label: ""},
+    ufa: {index: 1, geojson_label: "ufa"},
+    cf: {index: 2, geojson_label: "communal"},
+    vdc: {index: 3, geojson_label: "ventes_de_coupe"},
+    cpaet: {index: 4, geojson_label: "CPAET"},
+    cfad: {index: 5, geojson_label: "CFAD"},
+    pea: {index: 6, geojson_label: "PEA"},
+    cdc: {index: 7, geojson_label: "cdc"},
+    ccf: {index: 8, geojson_label: "ccf"}
   }.with_indifferent_access.freeze
   TYPES_WITH_CODE = TYPES.map { |k, v| {k => v[:index]} }.reduce({}, :merge).with_indifferent_access
 
+  def self.label(key)
+    I18n.t(key, scope: :forest_types)
+  end
+
   def self.select_collection
-    TYPES.map { |k, h| [h[:label], h[:index]] }
+    TYPES.map { |k, h| [label(k), h[:index]] }
   end
 end

--- a/app/models/forest_type.rb
+++ b/app/models/forest_type.rb
@@ -8,7 +8,7 @@ class ForestType
     cfad: {index: 5, label: "CFAD", geojson_label: "CFAD"},
     pea: {index: 6, label: "PEA", geojson_label: "PEA"},
     cdc: {index: 7, label: "Concession de conservation", geojson_label: "cdc"},
-    cdcf: {index: 8, label: "Concession de concession forestière", geojson_label: "cdcf"}
+    ccf: {index: 8, label: "Concession de concession forestière", geojson_label: "ccf"}
   }.with_indifferent_access.freeze
   TYPES_WITH_CODE = TYPES.map { |k, v| {k => v[:index]} }.reduce({}, :merge).with_indifferent_access
 

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -169,7 +169,10 @@ class OperatorDocument < ApplicationRecord
     # 2 - The Fmu was deleted (destroyed_by_association)
     # 3 - The Required Operator Document was deleted (destroyed_by_association)
     # 4 - The Operator is no longer active for this Fmu
-    return super if destroyed_by_association || (fmu_id && (operator_id != fmu.operator&.id))
+    # 5 - The Required Operator Document no longer applies to the Fmu forest type
+    return super if destroyed_by_association ||
+      (fmu_id && (operator_id != fmu.operator&.id)) ||
+      (fmu_id && no_longer_required_for_fmu_forest_type?)
 
     update!(
       status: OperatorDocument.statuses[:doc_not_provided],
@@ -181,6 +184,11 @@ class OperatorDocument < ApplicationRecord
   end
 
   private
+
+  def no_longer_required_for_fmu_forest_type?
+    forest_type_indexes = required_operator_document[:forest_types]
+    forest_type_indexes.present? && forest_type_indexes.exclude?(Fmu.forest_types[fmu.forest_type])
+  end
 
   def disconnect_annexes
     self.annex_documents = []

--- a/app/models/operator_document.rb
+++ b/app/models/operator_document.rb
@@ -186,8 +186,7 @@ class OperatorDocument < ApplicationRecord
   private
 
   def no_longer_required_for_fmu_forest_type?
-    forest_type_indexes = required_operator_document[:forest_types]
-    forest_type_indexes.present? && forest_type_indexes.exclude?(Fmu.forest_types[fmu.forest_type])
+    !required_operator_document.applies_to_forest_type?(fmu.forest_type)
   end
 
   def disconnect_annexes

--- a/app/models/operator_document_filter_tree.rb
+++ b/app/models/operator_document_filter_tree.rb
@@ -48,7 +48,7 @@ class OperatorDocumentFilterTree
 
   def forest_types
     ForestType::TYPES.map do |key, value|
-      {key: key, id: value[:index], name: value[:label]}
+      {key: key, id: value[:index], name: ForestType.label(key)}
     end.sort_by { |x| x[:name] }
   end
 
@@ -117,7 +117,7 @@ class OperatorDocumentFilterTree
 
   def serialize_forest_types(forest_types)
     ForestType::TYPES.filter_map do |key, value|
-      {key: key, id: value[:index], name: value[:label]} if forest_types.include?(key.to_s)
+      {key: key, id: value[:index], name: ForestType.label(key)} if forest_types.include?(key.to_s)
     end
   end
 

--- a/app/models/required_operator_document_fmu.rb
+++ b/app/models/required_operator_document_fmu.rb
@@ -54,10 +54,12 @@ class RequiredOperatorDocumentFmu < RequiredOperatorDocument
   end
 
   def fmus
-    return Fmu.where.not(country_id: Country.active) if country_id.blank?
-
-    fmu_attributes = {country_id: country_id}
-    fmu_attributes[:forest_type] = forest_types if forest_types.present?
-    Fmu.where(fmu_attributes)
+    scope = if country_id.blank?
+      Fmu.where.not(country_id: Country.active)
+    else
+      Fmu.where(country_id: country_id)
+    end
+    scope = scope.where(forest_type: forest_types) if forest_types.present?
+    scope
   end
 end

--- a/app/models/required_operator_document_fmu.rb
+++ b/app/models/required_operator_document_fmu.rb
@@ -27,6 +27,14 @@ class RequiredOperatorDocumentFmu < RequiredOperatorDocument
 
   validates :contract_signature, absence: true
 
+  # empty forest_types means the document applies to all forest types
+  scope :for_forest_type, ->(forest_type) {
+    where(
+      "COALESCE(cardinality(forest_types), 0) = 0 OR :forest_type = ANY (forest_types)",
+      forest_type: Fmu.forest_types[forest_type]
+    )
+  }
+
   after_create :create_operator_document_fmus, unless: :disable_document_creation
 
   def create_operator_document_fmus
@@ -39,6 +47,10 @@ class RequiredOperatorDocumentFmu < RequiredOperatorDocument
         end
       end
     end
+  end
+
+  def applies_to_forest_type?(forest_type)
+    forest_types.blank? || forest_types.include?(forest_type.to_sym)
   end
 
   def fmus

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,6 +335,7 @@ en:
       download_shapefile: 'Download shapefile'
       download_filtered_shapefiles: 'Download Filtered Shapefiles'
       confirm_delete: 'Are you sure you want to delete this FMU?'
+      forest_type_warning: "Changing the forest type will update this FMU's document list. Documents that are not required for the new forest type will be removed, and any newly required documents will have to be provided."
     operator_page:
       producer: 'Producer'
       producer_activated: 'Producer activated'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1712,6 +1712,17 @@ en:
       doc_not_required: 'Not Required Document'
       producer: 'Producer'
 
+  forest_types:
+    fmu: 'FMU'
+    ufa: 'UFA'
+    cf: 'Communal forest'
+    vdc: 'Sale of Standing Volume'
+    cpaet: 'CPAET'
+    cfad: 'CFAD'
+    pea: 'PEA'
+    cdc: 'Conservation Concession'
+    ccf: 'Forest Concession Contracts'
+
   filters:
     operator: 'Operator'
     governance: 'Governance'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -349,6 +349,7 @@ es:
       download_shapefile: 'Descargar shapefile'
       download_filtered_shapefiles: 'Descargar Shapefiles Filtrados'
       confirm_delete: '¿Estás seguro de que quieres eliminar este FMU?'
+      forest_type_warning: 'Cambiar el tipo de bosque actualizará la lista de documentos de esta FMU. Los documentos que no sean necesarios para el nuevo tipo de bosque se eliminarán, y deberán proporcionarse los nuevos documentos requeridos.'
     operator_page:
       producer: 'Productor'
       producer_activated: 'Productor activado'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1721,6 +1721,15 @@ es:
       doc_not_required: 'Documento No Requerido'
       producer: 'Productor'
 
+  forest_types:
+    fmu: 'UGF'
+    ufa: 'UFA'
+    cf: 'Bosque comunal'
+    vdc: 'Venta de Volumen en Pie'
+    cpaet: 'CPAET'
+    cfad: 'CFAD'
+    pea: 'PEA'
+
   filters:
     operator: 'Operador'
     governance: 'Gobernanza'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -365,6 +365,7 @@ fr:
       download_shapefile: 'Télécharger shapefile'
       download_filtered_shapefiles: 'Télécharger les shapefiles filtrés'
       confirm_delete: 'Êtes-vous sûr de vouloir supprimer cette FMU?'
+      forest_type_warning: 'Changer le type de forêt mettra à jour la liste des documents de cette FMU. Les documents qui ne sont pas requis pour le nouveau type de forêt seront supprimés, et tout nouveau document requis devra être fourni.'
     required_operator_document_page:
       exists: 'Existe'
       publication_authorization: 'Autorisation de publication'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1619,8 +1619,16 @@ fr:
       doc_not_required: 'Document non requis'
       producer: 'Producteur'
 
-
-
+  forest_types:
+    fmu: 'UGF'
+    ufa: 'UFA'
+    cf: 'Forêt Communale'
+    vdc: 'Vente de coupe'
+    cpaet: 'CPAET'
+    cfad: 'CFAD'
+    pea: 'PEA'
+    cdc: 'Concession de conservation'
+    ccf: 'Concession de concession forestière'
 
   filters:
     operator: 'Operateur'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1629,7 +1629,7 @@ fr:
     cfad: 'CFAD'
     pea: 'PEA'
     cdc: 'Concession de conservation'
-    ccf: 'Concession de concession forestière'
+    ccf: 'Contrats de concession forestière'
 
   filters:
     operator: 'Operateur'

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -83,4 +83,29 @@ namespace :data_migrations do
     warn "\n  #{errors} version(s) failed to parse and were skipped." if errors > 0
     puts "\nFinished migrating PaperTrail versions to JSON columns. You can now remove the old YAML columns with a separate migration."
   end
+
+  desc "Set forest_types to CDCF on existing COD required operator documents and migrate COD FMUs to the CDCF forest type."
+  task new_drc_concession: :environment do
+    for_real = ENV["FOR_REAL"] == "true"
+    puts "DRY RUN" unless for_real
+
+    cod = Country.find_by!(iso: "COD")
+    cdcf_index = ForestType::TYPES[:cdcf][:index]
+
+    required_documents = RequiredOperatorDocumentFmu.with_archived.where(country_id: cod.id)
+    puts "Setting forest_types to [cdcf] on #{required_documents.count} required operator document(s) for COD..."
+    required_documents.find_each do |document|
+      document.forest_types = [cdcf_index]
+      document.save!(validate: false) if for_real
+    end
+
+    fmus = Fmu.where(country_id: cod.id)
+    puts "Setting forest_type to cdcf on #{fmus.count} FMU(s) for COD..."
+    fmus.find_each do |fmu|
+      fmu.forest_type = :cdcf
+      fmu.save!(validate: false) if for_real
+    end
+
+    puts "Done."
+  end
 end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -84,25 +84,25 @@ namespace :data_migrations do
     puts "\nFinished migrating PaperTrail versions to JSON columns. You can now remove the old YAML columns with a separate migration."
   end
 
-  desc "Set forest_types to CDCF on existing COD required operator documents and migrate COD FMUs to the CDCF forest type."
+  desc "Set forest_types to CCF on existing COD required operator documents and migrate COD FMUs to the CCF forest type."
   task new_drc_concession: :environment do
     for_real = ENV["FOR_REAL"] == "true"
     puts "DRY RUN" unless for_real
 
     cod = Country.find_by!(iso: "COD")
-    cdcf_index = ForestType::TYPES[:cdcf][:index]
+    ccf_index = ForestType::TYPES[:ccf][:index]
 
     required_documents = RequiredOperatorDocumentFmu.with_archived.where(country_id: cod.id)
-    puts "Setting forest_types to [cdcf] on #{required_documents.count} required operator document(s) for COD..."
+    puts "Setting forest_types to [ccf] on #{required_documents.count} required operator document(s) for COD..."
     required_documents.find_each do |document|
-      document.forest_types = [cdcf_index]
+      document.forest_types = [ccf_index]
       document.save!(validate: false) if for_real
     end
 
     fmus = Fmu.where(country_id: cod.id)
-    puts "Setting forest_type to cdcf on #{fmus.count} FMU(s) for COD..."
+    puts "Setting forest_type to ccf on #{fmus.count} FMU(s) for COD..."
     fmus.find_each do |fmu|
-      fmu.forest_type = :cdcf
+      fmu.forest_type = :ccf
       fmu.save!(validate: false) if for_real
     end
 

--- a/spec/integration/v1/operator_document_filters_spec.rb
+++ b/spec/integration/v1/operator_document_filters_spec.rb
@@ -149,7 +149,7 @@ module V1
 
     def forest_type_entry(key)
       value = ForestType::TYPES[key]
-      {key: key.to_s, id: value[:index], name: value[:label]}
+      {key: key.to_s, id: value[:index], name: ForestType.label(key)}
     end
   end
 end

--- a/spec/models/fmu_operator_spec.rb
+++ b/spec/models/fmu_operator_spec.rb
@@ -219,6 +219,11 @@ RSpec.describe FmuOperator, type: :model do
         let!(:document_without_forest_types) { create(:required_operator_document_fmu, country: country, forest_types: []) }
         let!(:document_for_cf) { create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:cf][:index]]) }
         let!(:document_for_vdc) { create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:vdc][:index]]) }
+        let!(:document_with_null_forest_types) do
+          create(:required_operator_document_fmu, country: country, forest_types: []).tap do |document|
+            document.update_column(:forest_types, nil)
+          end
+        end
 
         def operator_document_ids(fmu)
           OperatorDocumentFmu.where(fmu_id: fmu.id, operator_id: operator.id).pluck(:required_operator_document_id)
@@ -228,7 +233,7 @@ RSpec.describe FmuOperator, type: :model do
           fmu = create(:fmu, country: country, forest_type: :cf)
           create(:fmu_operator, operator: operator, fmu: fmu, current: true)
 
-          expect(operator_document_ids(fmu)).to match_array([document_without_forest_types.id, document_for_cf.id])
+          expect(operator_document_ids(fmu)).to match_array([document_without_forest_types.id, document_with_null_forest_types.id, document_for_cf.id])
         end
       end
     end

--- a/spec/models/fmu_operator_spec.rb
+++ b/spec/models/fmu_operator_spec.rb
@@ -212,6 +212,25 @@ RSpec.describe FmuOperator, type: :model do
           end
         end
       end
+
+      context "when matching required documents by forest type" do
+        let(:country) { create(:country) }
+        let(:operator) { create(:operator, country: country, fa_id: "fa_id") }
+        let!(:document_without_forest_types) { create(:required_operator_document_fmu, country: country, forest_types: []) }
+        let!(:document_for_cf) { create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:cf][:index]]) }
+        let!(:document_for_vdc) { create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:vdc][:index]]) }
+
+        def operator_document_ids(fmu)
+          OperatorDocumentFmu.where(fmu_id: fmu.id, operator_id: operator.id).pluck(:required_operator_document_id)
+        end
+
+        it "creates documents with matching forest type and documents without forest types" do
+          fmu = create(:fmu, country: country, forest_type: :cf)
+          create(:fmu_operator, operator: operator, fmu: fmu, current: true)
+
+          expect(operator_document_ids(fmu)).to match_array([document_without_forest_types.id, document_for_cf.id])
+        end
+      end
     end
   end
 

--- a/spec/models/fmu_operator_spec.rb
+++ b/spec/models/fmu_operator_spec.rb
@@ -235,6 +235,19 @@ RSpec.describe FmuOperator, type: :model do
 
           expect(operator_document_ids(fmu)).to match_array([document_without_forest_types.id, document_with_null_forest_types.id, document_for_cf.id])
         end
+
+        context "when the fmu country is not active" do
+          let(:country) { create(:country, is_active: false) }
+          let!(:generic_document) { create(:required_operator_document_fmu, country: nil, forest_types: []) }
+          let!(:generic_document_for_vdc) { create(:required_operator_document_fmu, country: nil, forest_types: [ForestType::TYPES[:vdc][:index]]) }
+
+          it "creates documents from generic required documents" do
+            fmu = create(:fmu, country: country, forest_type: :cf)
+            create(:fmu_operator, operator: operator, fmu: fmu, current: true)
+
+            expect(operator_document_ids(fmu)).to match_array([generic_document.id])
+          end
+        end
       end
     end
   end

--- a/spec/models/fmu_spec.rb
+++ b/spec/models/fmu_spec.rb
@@ -133,6 +133,23 @@ RSpec.describe Fmu, type: :model do
       end
     end
 
+    describe "#sync_operator_documents" do
+      it "updates the operator documents list when the forest type changes" do
+        country = create(:country)
+        operator = create(:operator, country: country, fa_id: "fa_id")
+        document_for_cf = create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:cf][:index]])
+        document_for_vdc = create(:required_operator_document_fmu, country: country, forest_types: [ForestType::TYPES[:vdc][:index]])
+        fmu = create(:fmu, country: country, forest_type: :cf, operator: operator)
+
+        operator_documents = OperatorDocumentFmu.where(fmu_id: fmu.id, operator_id: operator.id)
+        expect(operator_documents.pluck(:required_operator_document_id)).to eq([document_for_cf.id])
+
+        fmu.update!(forest_type: :vdc)
+
+        expect(operator_documents.pluck(:required_operator_document_id)).to eq([document_for_vdc.id])
+      end
+    end
+
     describe "#destroy" do
       it "destroy operator_documents associated with the fmu" do
         another_fmu = create(:fmu)

--- a/spec/models/required_operator_document_fmu_spec.rb
+++ b/spec/models/required_operator_document_fmu_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe RequiredOperatorDocumentFmu, type: :model do
 
         it { expect { subject }.to_not change { OperatorDocument.count } }
       end
+
+      context "when the document is generic (country is null)" do
+        let(:operator_country) { create :country, is_active: false }
+        let(:rod) { create :required_operator_document_fmu, country: nil, forest_types: forest_types }
+
+        context "with forest types matching the fmu" do
+          let(:forest_types) { [fmu.read_attribute_before_type_cast(:forest_type)] }
+
+          it { expect { subject }.to change { OperatorDocument.count }.from(0).to(1) }
+        end
+
+        context "with forest types not matching the fmu" do
+          let(:forest_types) { [ForestType::TYPES[:vdc][:index]] }
+
+          it { expect { subject }.to_not change { OperatorDocument.count } }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is adding a new concession type for DRC. There were no explicit types before, so existing FMUs will gain `ccf` type, and admin can change the type later through backoffice. That is why we have to enable changing the forest type for FMU and that will change the required documents as well. 

JIRA: https://gfw.atlassian.net/browse/OPEN-395