### PR TITLE
Fix/schema dump and mailers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ env:
   POSTGRES_PORT: 5432
   APP_URL: http://localhost:3000
   FRONTEND_URL: http://localhost:5000
+  OBSERVATIONS_TOOL_URL: http://localhost:5000/observations-tool
   SENDGRID_API_KEY: asdf
   CONTACT_EMAIL: nomail@nomail.com
   RESPONSIBLE_EMAIL: test@nomail.com

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,6 +24,7 @@ class UserMailer < ApplicationMailer
   def inactive_account_warning(user, disable_date)
     @user = user
     @disable_date = disable_date
+    @link = generate_app_url(user)
     mail(to: user.email, subject: I18n.t("user_mailer.inactive_account_warning.subject", disable_date: I18n.l(disable_date)))
   end
 
@@ -41,6 +42,16 @@ class UserMailer < ApplicationMailer
       ENV["OBSERVATIONS_TOOL_URL"] + "/reset-password?reset_password_token=" + generate_reset_token(user)
     else
       ENV["FRONTEND_URL"] + "/reset-password?reset_password_token=" + generate_reset_token(user)
+    end
+  end
+
+  def generate_app_url(user)
+    if user.admin? || user.bo_manager?
+      admin_root_url
+    elsif user.observation_tool_user?
+      ENV["OBSERVATIONS_TOOL_URL"]
+    else
+      ENV["FRONTEND_URL"]
     end
   end
 

--- a/app/models/concerns/roleable.rb
+++ b/app/models/concerns/roleable.rb
@@ -17,6 +17,10 @@ module Roleable
       user_permission.user_role.in?("admin")
     end
 
+    def bo_manager?
+      user_permission.user_role.in?("bo_manager")
+    end
+
     def holding?
       user_permission.user_role.in?("holding")
     end

--- a/app/views/mailers/user_mailer/inactive_account_warning.html.mjml
+++ b/app/views/mailers/user_mailer/inactive_account_warning.html.mjml
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  <%= t(".cta", link: link_to(ENV["FRONTEND_URL"], ENV["FRONTEND_URL"], target: "_blank")).html_safe %>
+  <%= t(".cta", link: link_to(@link, @link, target: "_blank")).html_safe %>
 </p>
 
 <p>

--- a/app/views/mailers/user_mailer/inactive_account_warning.text.erb
+++ b/app/views/mailers/user_mailer/inactive_account_warning.text.erb
@@ -2,7 +2,7 @@
 
 <%= t(".message", disable_date: l(@disable_date)) %>
 
-<%= t(".cta", link: ENV["FRONTEND_URL"]) %>
+<%= t(".cta", link: @link) %>
 
 <%= t("mailers.contact_us") %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,8 @@
 default: &default
   adapter: postgis
   encoding: unicode
+  # postgis extensions put tiger/topology on the database search_path, keep them out of schema.rb
+  schema_search_path: public
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV["POSTGRES_USER"] %>
   password: <%= ENV["POSTGRES_PASSWORD"] %>

--- a/config/initializers/extensions_ignore_tables.rb
+++ b/config/initializers/extensions_ignore_tables.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-# https://stackoverflow.com/questions/40882420/rails-postgis-error-cannot-drop-table-spatial-ref-sys
-::ActiveRecord::SchemaDumper.ignore_tables |=
-  %w[layer spatial_ref_sys topology us_gaz us_lex us_rules]
+# public tables owned by extensions, dumping them makes schema load fail on drop
+# tiger and topology schemas are already excluded by schema_search_path in database.yml
+::ActiveRecord::SchemaDumper.ignore_tables |= %w[spatial_ref_sys us_gaz us_lex us_rules]

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -11,8 +11,16 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.forgotten_password test_user_operator
   end
 
-  def inactive_account_warning
+  def inactive_account_warning_observer
+    UserMailer.inactive_account_warning test_user_observer, 30.days.from_now.to_date
+  end
+
+  def inactive_account_warning_operator
     UserMailer.inactive_account_warning test_user_operator, 30.days.from_now.to_date
+  end
+
+  def inactive_account_warning_admin
+    UserMailer.inactive_account_warning test_user_admin, 30.days.from_now.to_date
   end
 
   def account_deactivated_for_inactivity
@@ -20,6 +28,10 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   private
+
+  def test_user_admin
+    User.new(email: "john@example.com", first_name: "John", last_name: "Tester", locale: "en", user_permission: UserPermission.new(user_role: "admin"))
+  end
 
   def test_user_observer
     User.new(email: "john@example.com", first_name: "John", last_name: "Tester", locale: "en", user_permission: UserPermission.new(user_role: "ngo_manager"))

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -11,6 +11,14 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.forgotten_password test_user_operator
   end
 
+  def inactive_account_warning
+    UserMailer.inactive_account_warning test_user_operator, 30.days.from_now.to_date
+  end
+
+  def account_deactivated_for_inactivity
+    UserMailer.account_deactivated_for_inactivity test_user_operator
+  end
+
   private
 
   def test_user_observer

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "links to the portal" do
       expect(mail.body.encoded).to include(ENV["FRONTEND_URL"])
+      expect(mail.body.encoded).not_to include(ENV["OBSERVATIONS_TOOL_URL"])
     end
 
     context "when user is an observation tool user" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe UserMailer, type: :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to match(I18n.t("user_mailer.inactive_account_warning.message", disable_date: I18n.l(disable_date)))
     end
+
+    it "links to the portal" do
+      expect(mail.body.encoded).to include(ENV["FRONTEND_URL"])
+    end
+
+    context "when user is an observation tool user" do
+      let(:user) { create(:ngo_manager) }
+
+      it "links to the observations tool" do
+        expect(mail.body.encoded).to include(ENV["OBSERVATIONS_TOOL_URL"])
+      end
+    end
+
+    context "when user is an admin" do
+      let(:user) { create(:admin) }
+
+      it "links to the admin panel" do
+        expect(mail.body.encoded).to include(admin_root_url)
+      end
+    end
   end
 
   describe "account_deactivated_for_inactivity" do


### PR DESCRIPTION
- fixing schema dumper to not include some of PostGIS extension's tables (there were ignored table already listed in the project, but the list grew substantially after upgrading to a newer version)
- adding missing mailer previews
- fixing the link to the login page in the inactivity mailer - should be based on user role